### PR TITLE
Small changes to (hopefully) prettify Semantics

### DIFF
--- a/semantics-3.0/Semantics4.hs
+++ b/semantics-3.0/Semantics4.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 module Semantics4 where
 
 import           Data.List       (foldl')
 import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import qualified Data.Map.Strict as Map
 import           Data.Set        (Set)
-import qualified Data.Set        as S
+import qualified Data.Set        as Set
 
 type SlotNumber = Integer
 type SlotInterval = (SlotNumber, SlotNumber)
@@ -39,7 +40,6 @@ data Value = AvailableMoney AccountId
            | SlotIntervalStart
            | SlotIntervalEnd
            | UseValue ValueId
---           | OracleValue OracleId Value
   deriving (Eq,Ord,Show,Read)
 
 data Observation = AndObs Observation Observation
@@ -53,7 +53,6 @@ data Observation = AndObs Observation Observation
                  | ValueEQ Value Value
                  | TrueObs
                  | FalseObs
---                 | OracleValueProvided OracleId
   deriving (Eq,Ord,Show,Read)
 
 type Bound = (Integer, Integer)
@@ -80,8 +79,8 @@ data Contract = Refund
               | Let ValueId Value Contract
   deriving (Eq,Ord,Show,Read)
 
-data State = State { account :: Map AccountId Money
-                   , choice  :: Map ChoiceId ChosenNum
+data State = State { accounts :: Map AccountId Money
+                   , choices  :: Map ChoiceId ChosenNum
                    , boundValues :: Map ValueId Integer
                    , minSlot :: SlotNumber }
   deriving (Eq,Ord,Show,Read)
@@ -96,25 +95,29 @@ data Input = IDeposit AccountId Party Money
 
 -- TRANSACTION OUTCOMES
 
-type TransactionOutcomes = M.Map Party Money
+type TransactionOutcomes = Map Party Money
+
 
 emptyOutcome :: TransactionOutcomes
-emptyOutcome = M.empty
+emptyOutcome = Map.empty
+
 
 isEmptyOutcome :: TransactionOutcomes -> Bool
 isEmptyOutcome trOut = all (== 0) trOut
 
+
 -- Adds a value to the map of outcomes
 addOutcome :: Party -> Money -> TransactionOutcomes -> TransactionOutcomes
-addOutcome party diffValue trOut = M.insert party newValue trOut
+addOutcome party diffValue trOut = Map.insert party newValue trOut
   where
-    newValue = case M.lookup party trOut of
+    newValue = case Map.lookup party trOut of
         Just value -> value + diffValue
         Nothing    -> diffValue
 
+
 -- Add two transaction outcomes together
 combineOutcomes :: TransactionOutcomes -> TransactionOutcomes -> TransactionOutcomes
-combineOutcomes = M.unionWith (+)
+combineOutcomes = Map.unionWith (+)
 
 -- INTERVALS
 
@@ -126,6 +129,7 @@ data IntervalError = InvalidInterval SlotInterval
 data IntervalResult = IntervalTrimmed Environment State
                     | IntervalError IntervalError
   deriving (Eq,Ord,Show,Read)
+
 
 fixInterval :: SlotInterval -> State -> IntervalResult
 fixInterval i@(l, h) st@State{minSlot} | h < l = IntervalError $ InvalidInterval i
@@ -142,16 +146,17 @@ fixInterval i@(l, h) st@State{minSlot} | h < l = IntervalError $ InvalidInterval
 -- Evaluate a value
 evalValue :: Environment -> State -> Value -> Integer
 evalValue env state value = case value of
-    AvailableMoney accId     -> M.findWithDefault 0 accId $ account state
+    AvailableMoney accId     -> Map.findWithDefault 0 accId $ accounts state
     Constant integer         -> integer
     NegValue val             -> go val
     AddValue lhs rhs         -> go lhs + go rhs
     SubValue lhs rhs         -> go lhs + go rhs
-    ChoiceValue choId defVal -> M.findWithDefault (go defVal) choId $ choice state
+    ChoiceValue choiceId defVal -> Map.findWithDefault (go defVal) choiceId $ choices state
     SlotIntervalStart        -> fst $ slotInterval env
     SlotIntervalEnd          -> snd $ slotInterval env
-    UseValue valId           -> M.findWithDefault 0 valId $ boundValues state
+    UseValue valId           -> Map.findWithDefault 0 valId $ boundValues state
   where go = evalValue env state
+
 
 -- Evaluate an observation
 evalObservation :: Environment -> State -> Observation -> Bool
@@ -159,7 +164,7 @@ evalObservation env state obs = case obs of
     AndObs lhs rhs       -> goObs lhs && goObs rhs
     OrObs lhs rhs        -> goObs lhs || goObs rhs
     NotObs subObs        -> not $ goObs subObs
-    ChoseSomething choId -> choId `M.member` choice state
+    ChoseSomething choiceId -> choiceId `Map.member` choices state
     ValueGE lhs rhs      -> goVal lhs >= goVal rhs
     ValueGT lhs rhs      -> goVal lhs > goVal rhs
     ValueLT lhs rhs      -> goVal lhs < goVal rhs
@@ -171,47 +176,56 @@ evalObservation env state obs = case obs of
     goObs = evalObservation env state
     goVal = evalValue env state
 
--- Pick the first account with money in it
+
+-- | Pick the first account with money in it
 refundOne :: Map AccountId Money -> Maybe ((Party, Money), Map AccountId Money)
 refundOne accounts = do
-    ((accId, mon), rest) <- M.minViewWithKey accounts
-    if mon > 0 then return ((accountOwner accId, mon), rest) else refundOne rest
+    ((accId, money), rest) <- Map.minViewWithKey accounts
+    if money > 0 then return ((accountOwner accId, money), rest) else refundOne rest
 
--- Obtains the amount of money available an account
-moneyInAccount :: Map AccountId Money -> AccountId -> Money
-moneyInAccount accs accId = M.findWithDefault 0 accId accs
 
--- Sets the amount of money available in an account
-updateMoneyInAccount :: Map AccountId Money -> AccountId -> Money -> Map AccountId Money
-updateMoneyInAccount accs accId mon | mon <= 0 = M.delete accId accs
-                                    | otherwise = M.insert accId mon accs
+-- | Obtains the amount of money available an account
+moneyInAccount :: AccountId -> Map AccountId Money -> Money
+moneyInAccount = Map.findWithDefault 0
 
--- Withdraw up to the given amount of money from an account
--- Return the amount of money withdrawn
+
+-- | Sets the amount of money available in an account
+updateMoneyInAccount :: AccountId -> Money -> Map AccountId Money -> Map AccountId Money
+updateMoneyInAccount accId money | money <= 0 = Map.delete accId
+                                 | otherwise = Map.insert accId money
+
+
+{-| Withdraw up to the given amount of money from an account
+    Return the amount of money withdrawn
+-}
 withdrawMoneyFromAccount
-    :: Map AccountId Money -> AccountId -> Money -> (Money, Map AccountId Money)
-withdrawMoneyFromAccount accs accId mon = (withdrawnMoney, newAcc)
+  :: AccountId -> Money -> Map AccountId Money -> (Money, Map AccountId Money)
+withdrawMoneyFromAccount accId money accounts = (withdrawnMoney, newAcc)
   where
-    avMoney = moneyInAccount accs accId
-    withdrawnMoney = min avMoney mon
-    newAvMoney = avMoney - withdrawnMoney
-    newAcc = updateMoneyInAccount accs accId newAvMoney
+  avMoney        = moneyInAccount accId accounts
+  withdrawnMoney = min avMoney money
+  newAvMoney     = avMoney - withdrawnMoney
+  newAcc         = updateMoneyInAccount accId newAvMoney accounts
 
--- Add the given amount of money to an accoun (only if it is positive)
--- Return the updated Map
-addMoneyToAccount :: Map AccountId Money -> AccountId -> Money -> Map AccountId Money
-addMoneyToAccount accs accId mon | mon <= 0 = accs
-                                 | otherwise = updateMoneyInAccount accs accId newAvMoney
+
+{-| Add the given amount of money to an accoun (only if it is positive).
+    Return the updated Map
+-}
+addMoneyToAccount :: AccountId -> Money -> Map AccountId Money -> Map AccountId Money
+addMoneyToAccount accId money accounts | money <= 0  = accounts
+                                       | otherwise = updateMoneyInAccount accId newAvMoney accounts
   where
-    avMoney = moneyInAccount accs accId
-    newAvMoney = avMoney + mon
+    avMoney = moneyInAccount accId accounts
+    newAvMoney = avMoney + money
 
--- Gives the given amount of money to the given payee
--- Return the appropriate effect and updated Map
-giveMoney :: Map AccountId Money -> Payee -> Money -> (ReduceEffect, Map AccountId Money)
-giveMoney accs (Party party) mon = (ReduceNormalPay party mon, accs)
-giveMoney accs (Account accId) mon = (ReduceNoEffect, newAccs)
-    where newAccs = addMoneyToAccount accs accId mon
+
+{-| Gives the given amount of money to the given payee.
+    Returns the appropriate effect and updated accounts
+-}
+giveMoney :: Payee -> Money -> Map AccountId Money -> (ReduceEffect, Map AccountId Money)
+giveMoney (Party   party) money accounts = (ReduceNormalPay party money, accounts)
+giveMoney (Account accId) money accounts = (ReduceNoEffect, newAccs)
+  where newAccs = addMoneyToAccount accId money accounts
 
 -- REDUCE
 
@@ -235,40 +249,43 @@ data ReduceResult = Reduced ReduceWarning ReduceEffect State Contract
                   | ReduceError ReduceError
   deriving (Eq,Ord,Show,Read)
 
--- Carry a step of the contract with no inputs
+
+-- | Carry a step of the contract with no inputs
 reduce :: Environment -> State -> Contract -> ReduceResult
-reduce _ state c@Refund = case refundOne $ account state of
-    (Just ((party, money), newAccount)) ->
-        let newState = state { account = newAccount }
-        in  Reduced ReduceNoWarning (ReduceNormalPay party money) newState c
-    Nothing -> NotReduced
-reduce env state (Pay accId payee val nc) = if mon <= 0
-    then Reduced (ReduceNonPositivePay accId payee mon) ReduceNoEffect state nc
-    else Reduced noMonWarn payEffect (state { account = finalAccs }) nc
-  where
-    mon = evalValue env state val
-    (paidMon, newAccs) = withdrawMoneyFromAccount (account state) accId mon
-    noMonWarn = if paidMon < mon then ReducePartialPay accId payee paidMon mon else ReduceNoWarning
-    (payEffect, finalAccs) = giveMoney newAccs payee paidMon
-reduce env state (If obs cont1 cont2) = Reduced ReduceNoWarning ReduceNoEffect state nc
-  where nc = if evalObservation env state obs then cont1 else cont2
-reduce env state (When _ timeout c)
-    | endSlot < timeout = NotReduced
-    | startSlot >= timeout = Reduced ReduceNoWarning ReduceNoEffect state c
-    | otherwise = ReduceError ReduceAmbiguousSlotInterval
-  where
-    startSlot = fst $ slotInterval env
-    endSlot = snd $ slotInterval env
-reduce env state (Let valId val cont) =
-    Reduced warn ReduceNoEffect ns cont
-  where
-    sv = boundValues $ state
-    evVal = evalValue env state val
-    nsv = M.insert valId evVal sv
-    ns = state { boundValues = nsv }
-    warn = case M.lookup valId sv of
-             Just oldVal -> ReduceShadowing valId oldVal evVal
-             Nothing -> ReduceNoWarning
+reduce env state@State{..} contract = case contract of
+    Refund -> case refundOne accounts of
+        Just ((party, money), newAccounts) ->
+            let newState = state { accounts = newAccounts }
+            in  Reduced ReduceNoWarning (ReduceNormalPay party money) newState Refund
+        Nothing -> NotReduced
+    Pay accId payee val cont -> if amountToPay <= 0
+        then Reduced (ReduceNonPositivePay accId payee amountToPay) ReduceNoEffect state cont
+        else let
+                (paidMoney, newAccs) = withdrawMoneyFromAccount accId amountToPay accounts
+                paidAmount = paidMoney
+                warning = if paidAmount < amountToPay
+                          then ReducePartialPay accId payee paidAmount amountToPay
+                          else ReduceNoWarning
+                (payEffect, finalAccs) = giveMoney payee paidMoney newAccs
+            in Reduced warning payEffect (state { accounts = finalAccs }) cont
+      where amountToPay = evalValue env state val
+    If obs cont1 cont2 -> Reduced ReduceNoWarning ReduceNoEffect state cont
+      where cont = if evalObservation env state obs then cont1 else cont2
+    When _ timeout cont
+        | endSlot < timeout -> NotReduced
+        | startSlot >= timeout -> Reduced ReduceNoWarning ReduceNoEffect state cont
+        | otherwise -> ReduceError ReduceAmbiguousSlotInterval
+      where
+        startSlot = fst $ slotInterval env
+        endSlot   = snd $ slotInterval env
+    Let valId val cont -> Reduced warn ReduceNoEffect newState cont
+      where
+        evVal = evalValue env state val
+        newState = state { boundValues = Map.insert valId evVal boundValues }
+        warn = case Map.lookup valId boundValues of
+              Just oldVal -> ReduceShadowing valId oldVal evVal
+              Nothing -> ReduceNoWarning
+
 
 -- REDUCE ALL
 
@@ -277,18 +294,18 @@ data ReduceAllResult = ReducedAll [ReduceWarning] [ReduceEffect] State Contract
   deriving (Eq,Ord,Show,Read)
 
 -- Reduce until it cannot be reduced more
-reduceAllAux
-    :: Environment -> State -> Contract -> [ReduceWarning] -> [ReduceEffect] -> ReduceAllResult
-reduceAllAux env sta c wa ef = case reduce env sta c of
-    Reduced twa tef nsta nc ->
-        let nwa = if twa == ReduceNoWarning then wa else twa : wa
-        in  let nef = if tef == ReduceNoEffect then ef else tef : ef
-            in  reduceAllAux env nsta nc nwa nef
+reduceAllAux :: Environment -> State -> Contract -> [ReduceWarning] -> [ReduceEffect] -> ReduceAllResult
+reduceAllAux env state contract warnings effects = case reduce env state contract of
+    Reduced warning effect newState cont -> let
+        newWarnings = if warning == ReduceNoWarning then warnings else warning : warnings
+        newEffects  = if effect  == ReduceNoEffect  then effects  else effect : effects
+        in  reduceAllAux env newState cont newWarnings newEffects
     ReduceError err -> ReduceAllError err
-    NotReduced -> ReducedAll (reverse wa) (reverse ef) sta c
+    NotReduced -> ReducedAll (reverse warnings) (reverse effects) state contract
+
 
 reduceAll :: Environment -> State -> Contract -> ReduceAllResult
-reduceAll env sta c = reduceAllAux env sta c [] []
+reduceAll env state contract = reduceAllAux env state contract [] []
 
 -- APPLY
 
@@ -299,26 +316,26 @@ data ApplyResult = Applied State Contract
                  | ApplyError ApplyError
   deriving (Eq,Ord,Show,Read)
 
+
 -- Apply a single Input to the contract (assumes the contract is reduced)
 applyCases :: Environment -> State -> Input -> [Case] -> ApplyResult
-applyCases env state (IDeposit accId1 party1 mon1) (Case (Deposit accId2 party2 val2) nc : _)
-    | accId1 == accId2 && party1 == party2 && mon1 == mon2 = Applied newState nc
-  where
-    mon2 = evalValue env state val2
-    accs = account state
-    newAccs = addMoneyToAccount accs accId1 mon1
-    newState = state { account = newAccs }
-applyCases _ state (IChoice choId1 cho1) (Case (Choice choId2 bounds2) nc : _)
-    | choId1 == choId2 && inBounds cho1 bounds2 = Applied newState nc
-    where newState = state { choice = M.insert choId1 cho1 $ choice state }
-applyCases env state INotify (Case (Notify obs) nc : _) | evalObservation env state obs =
-    Applied state nc
-applyCases env state act (_ : t) = applyCases env state act t
-applyCases _ _ _ [] = ApplyError ApplyNoMatch
+applyCases env state@State{..} input cases = case (input, cases) of
+    (IDeposit accId1 party1 money, Case (Deposit accId2 party2 val) cont : _)
+      | accId1 == accId2 && party1 == party2 && money == amount -> Applied newState cont
+      where
+        amount = evalValue env state val
+        newState = state { accounts = addMoneyToAccount accId1 money accounts }
+    (IChoice choId1 choice, Case (Choice choId2 bounds) cont : _)
+      | choId1 == choId2 && inBounds choice bounds -> Applied newState cont
+      where newState = state { choices = Map.insert choId1 choice choices }
+    (_, Case (Notify obs) cont : _) | evalObservation env state obs -> Applied state cont
+    (_, _ : rest) -> applyCases env state input rest
+    (_, []) -> ApplyError ApplyNoMatch
+
 
 apply :: Environment -> State -> Input -> Contract -> ApplyResult
-apply env state act (When cases _ _) = applyCases env state act cases
-apply _ _ _ _                        = ApplyError ApplyNoMatch
+apply env state input (When cases _ _) = applyCases env state input cases
+apply _ _ _ _                          = ApplyError ApplyNoMatch
 
 -- APPLY ALL
 
@@ -326,6 +343,7 @@ data ApplyAllResult = AppliedAll [ReduceWarning] [ReduceEffect] State Contract
                     | AAApplyError ApplyError
                     | AAReduceError ReduceError
   deriving (Eq,Ord,Show,Read)
+
 
 -- Apply a list of Inputs to the contract
 applyAllAux
@@ -336,16 +354,18 @@ applyAllAux
     -> [ReduceWarning]
     -> [ReduceEffect]
     -> ApplyAllResult
-applyAllAux env state c l wa ef = case reduceAll env state c of
-    ReduceAllError raerr -> AAReduceError raerr
-    ReducedAll twa tef tstate tc -> case l of
-        [] -> AppliedAll (wa ++ twa) (ef ++ tef) tstate tc
-        (h : t) -> case apply env tstate h tc of
-            Applied nst nc   -> applyAllAux env nst nc t (wa ++ twa) (ef ++ tef)
-            ApplyError aeerr -> AAApplyError aeerr
+applyAllAux env state contract inputs warnings effects = case reduceAll env state contract of
+    ReduceAllError error -> AAReduceError error
+    ReducedAll warns effs curState cont -> case inputs of
+        [] -> AppliedAll (warnings ++ warns) (effects ++ effs) curState cont
+        (input : rest) -> case apply env curState input cont of
+            Applied newState cont ->
+                applyAllAux env newState cont rest (warnings ++ warns) (effects ++ effs)
+            ApplyError error -> AAApplyError error
+
 
 applyAll :: Environment -> State -> Contract -> [Input] -> ApplyAllResult
-applyAll env state c l = applyAllAux env state c l [] []
+applyAll env state contract inputs = applyAllAux env state contract inputs [] []
 
 -- PROCESS
 
@@ -370,39 +390,43 @@ data ProcessResult = Processed [ProcessWarning]
                    | ProcessError ProcessError
   deriving (Eq,Ord,Show,Read)
 
-data Transaction = Transaction { interval :: SlotInterval
-                               , inputs   :: [Input] }
+data Transaction = Transaction { txInterval :: SlotInterval
+                               , txInputs   :: [Input] }
   deriving (Eq,Ord,Show,Read)
 
--- Extract necessary signatures from transaction inputs
+
+-- | Extract necessary signatures from transaction inputs
 getSignatures :: [Input] -> TransactionSignatures
-getSignatures = foldl' addSig S.empty
+getSignatures = foldl' addSig Set.empty
   where
-    addSig acc (IDeposit _ p _)           = S.insert p acc
-    addSig acc (IChoice (ChoiceId _ p) _) = S.insert p acc
+    addSig acc (IDeposit _ p _)           = Set.insert p acc
+    addSig acc (IChoice (ChoiceId _ p) _) = Set.insert p acc
     addSig acc INotify                    = acc
 
--- Extract total outcomes from transaction inputs and outputs
-getOutcomes :: [ReduceEffect] -> [Input] -> TransactionOutcomes
-getOutcomes eff inp = foldl' (\acc (p, m) -> addOutcome p m acc) emptyOutcome (incomes ++ outcomes)
-  where
-    incomes = [ (p, m) | ReduceNormalPay p m <- eff ]
-    outcomes = [ (p, m) | IDeposit _ p m <- inp ]
 
--- Try to process a transaction
-process :: Transaction -> State -> Contract -> ProcessResult
-process tra sta c = case fixInterval (interval tra) sta of
-    IntervalTrimmed env fixSta -> case applyAll env fixSta c inps of
-        AppliedAll wa ef nsta ncon ->
-            let sigs = getSignatures inps
-            in  let outcomes = getOutcomes ef inps
-                in  if c == ncon
+-- | Extract total outcomes from transaction inputs and outputs
+getOutcomes :: [ReduceEffect] -> [Input] -> TransactionOutcomes
+getOutcomes effect input = foldl' (\acc (p, m) -> addOutcome p m acc) emptyOutcome (incomes ++ outcomes)
+  where
+    incomes = [ (p, m) | ReduceNormalPay p m <- effect ]
+    outcomes = [ (p, m) | IDeposit _ p m <- input ]
+
+
+-- | Try to process a transaction
+processTransaction :: Transaction -> State -> Contract -> ProcessResult
+processTransaction tx state contract = case fixInterval (txInterval tx) state of
+    IntervalTrimmed env fixState -> case applyAll env fixState contract inputs of
+        AppliedAll warnings effects newState cont ->
+            let sigs = getSignatures inputs
+            in  let outcomes = getOutcomes effects inputs
+                in  if contract == cont
                     then ProcessError PEUselessTransaction
-                    else Processed wa ef sigs outcomes nsta ncon
-        AAApplyError aperr -> ProcessError $ PEApplyError aperr
-        AAReduceError reerr -> ProcessError $ PEReduceError reerr
-    IntervalError intErr -> ProcessError $ PEIntervalError intErr
-  where inps = inputs tra
+                    else Processed warnings effects sigs outcomes newState cont
+        AAApplyError error -> ProcessError $ PEApplyError error
+        AAReduceError error -> ProcessError $ PEReduceError error
+    IntervalError error -> ProcessError $ PEIntervalError error
+  where inputs = txInputs tx
+
 
 -- Calculates an upper bound for the maximum lifespan of a contract
 contractLifespan :: Contract -> Integer
@@ -416,4 +440,3 @@ contractLifespan contract = case contract of
         contractsLifespans = fmap (\(Case _ cont) -> contractLifespan cont) cases
         in maximum (timeout : contractLifespan subContract : contractsLifespans)
     Let _ _ cont -> contractLifespan cont
-


### PR DESCRIPTION
- Expand arguments names: c -> contract, sta -> state, mon -> money etc.
- Reduce code density by avoiding functions defined by patterns
- Rename `State` `account` and `choice` fields to `accounts` and `choices` respectively