### PR TITLE
Updated the Marlowe tutorials URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains Marlowe, a domain-specific language (DSL) for describin
 
 ## Learning about Marlowe and Marlowe Playground
 
-The [Marlowe tutorials](https://david.marlowe.iohkdev.io/tutorial/) introduce Marlowe and the Marlowe Playground.
+The [Marlowe tutorials](https://alpha.marlowe.iohkdev.io/tutorial/) introduce Marlowe and the Marlowe Playground.
 
 ## Versions of Marlowe
 


### PR DESCRIPTION
I saw that the previous page URL couldn't be reached, so I updated the URL to a working one.