### PR TITLE
SCP-4242 - Update Slot to POSIXTime

### DIFF
--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -2,13 +2,13 @@
 
 The challenge is to write a Marlowe contract that models payments for a utility, such as a mobile phone.
 
-The contract models the fact that you make regular payments to the company, every 30 slots. These payments are specified by the company, and you have 10 slots in which to pay. To start with, model the situation where the payment is 40 Ada each month.
+The contract models the fact that you make regular payments to the company, every 3 hours. These payments are specified by the company, and you have 1 hour in which to pay. To start with, model the situation where the payment is 40 Ada each month.
 
 At the start of the contract you make a deposit, say 150 Ada, and during the year, if you do not pay on time the company keeps the full deposit. If you have paid regularly, at the end of the contract  the deposit is paid back to you.
 
 ## Blockly and the Marlowe Playground
 
-If you are writing the contract in Blockly, model a contract that includes two cycles of 30 slots.
+If you are writing the contract in Blockly, model a contract that includes two cycles of 3 hours.
 
 If you are writing the contract in Haskell using the Marlowe Playground, write a version that is parameterised over the number of cycles.
 
@@ -17,7 +17,7 @@ If you are writing the contract in Haskell using the Marlowe Playground, write a
 You can try to add these variants, either one at a time, or in combination.
 
 - Model the situation where the company can specify (using a `Choice`) how much to pay at the time of payment rather than having it fixed in advance in the contract.
-- You can cancel the subscription giving 30 slots notice; on doing this you can recover half the deposit.
-- The company can increase the fixed fee by a given amount once only,  giving 20 slots notice. If this is done, then you can withdraw from the contract without losing your deposit.
+- You can cancel the subscription giving 3 hours notice; on doing this you can recover half the deposit.
+- The company can increase the fixed fee by a given amount once only,  giving 2 hours notice. If this is done, then you can withdraw from the contract without losing your deposit.
 
 

--- a/docs/tutorial-v3.0/actus-marlowe.adoc
+++ b/docs/tutorial-v3.0/actus-marlowe.adoc
@@ -97,7 +97,7 @@ ____
 
 === Guaranteed Coupon Bond Example
 
-This more complex bond involves an `investor` who deposits 1000 Ada, which is immediately paid to the `issuer`. The `issuer` then has to pay as interest 10 Ada every 10 slots. On maturity the investor should  receive back the interest plus the full value of the bond.
+This more complex bond involves an `investor` who deposits 1000 Ada, which is immediately paid to the `issuer`. The `issuer` then has to pay as interest 10 Ada every 3,600,000 milliseconds (1 hour). On maturity the investor should  receive back the interest plus the full value of the bond.
 
 [source,haskell]
 ----
@@ -106,24 +106,24 @@ couponBondFor3Month12Percent =
     When [ Case (Deposit "investor" "investor" (Constant 1000))
         -- and pays it to the issuer
         (Pay "investor" (Party "issuer") (Constant 1000)
-            -- after 10 slots expect to receive 10 Ada interest
+            -- after 1 hour expect to receive 10 Ada interest
             (When [ Case (Deposit "investor" "issuer" (Constant 10))
                 -- and pay it to the investor
                 (Pay "investor" (Party "investor" ) (Constant 10)
-                    -- same for 2nd 10 slots 
+                    -- same for 2nd hour 
                     (When [ Case (Deposit "investor" "issuer" (Constant 10))
                         (Pay "investor" (Party "investor" ) (Constant 10)
                             -- after maturity date investor
                             -- expects to receive notional + interest payment
                             (When [ Case (Deposit "investor" "issuer" (Constant 1010))
                                 (Pay "investor" (Party "investor" ) (Constant 1010) Refund)]
-                            (Slot 40)
+                            (POSIXTime 14400000)
                             Refund))]
-                    (Slot 30)
+                    (POSIXTime 10800000)
                     Refund))]
-            (Slot 20)
+            (POSIXTime 7200000)
             Refund))]
-    (Slot 10)
+    (POSIXTime 3600000)
     Refund
 ----
 

--- a/docs/tutorial-v3.0/escrow-ex.adoc
+++ b/docs/tutorial-v3.0/escrow-ex.adoc
@@ -84,25 +84,25 @@ the case that the condition of the `+When+` never becomes true. So, we  add time
                           (If (aliceChosen `ValueEQ` bobChosen)
                              agreement
                              arbitrate) ]
-                    60            -- ADDED
+                    21600000      -- ADDED
                     arbitrate),   -- ADDED
         Case bobChoice
               (When [ Case aliceChoice 
                           (If (aliceChosen `ValueEQ` bobChosen)
                               agreement
                               arbitrate) ]
-                    60            -- ADDED
+                    21600000      -- ADDED
                     arbitrate)    -- ADDED
         ]
-        40            -- ADDED
+        14400000      -- ADDED
         Refund        -- ADDED
 ----
 
-The outermost `When` calls for the first choice to be made by Alice or Bob: if neither of them has made a choice by time `40`, all the funds in the contract are refunded. 
+The outermost `When` calls for the first choice to be made by Alice or Bob: if neither of them has made a choice by time `14400000` milliseconds (4h), all the funds in the contract are refunded. 
 
-`Refund` is typically the last step in every “path” through a Marlowe contract, and its effect is to refund the money in the contract to the participants; we will describe this in more detail in a later tutorial. In this particular case, refund will happen after `40` slots.
+`Refund` is typically the last step in every “path” through a Marlowe contract, and its effect is to refund the money in the contract to the participants; we will describe this in more detail in a later tutorial. In this particular case, refund will happen after `14400000` miliseconds (4h).
 
-Looking at the inner constructs, if a choice has been made, then we wait for a second one. If that is not forthcoming by slot `60`, then Carol is called upon to arbitrate.footnote:[Again, we will describe how `arbitrate` and `agreement` work in a later tutorial.]
+Looking at the inner constructs, if a choice has been made, then we wait for a second one. If that is not forthcoming by timeout `21600000` (6h), then Carol is called upon to arbitrate.footnote:[Again, we will describe how `arbitrate` and `agreement` work in a later tutorial.]
 
 === Adding commitments
 
@@ -117,26 +117,26 @@ contract.
                           (If (aliceChosen `ValueEQ` bobChosen)
                              agreement
                              arbitrate) ]
-                    60 
+                    21600000 
                     arbitrate),
         Case bobChoice
               (When [ Case aliceChoice 
                           (If (aliceChosen `ValueEQ` bobChosen)
                               agreement
                               arbitrate) ]
-                    60            
+                    21600000            
                     arbitrate)   
         ]
-        40 
+        14400000 
         Refund)
     ]                                        
-    10                                       -- ADDED
+    3600000                                  -- ADDED
     Refund                                   -- ADDED
 ----
 
 A deposit of `price` is requested from `"alice"`: if it is given, then it is held in an account, also called `"alice"`. Accounts like this exist for the life of the contract only; each account belongs to a single contract. 
 
-There is a timeout of `10` slots on making the deposit; if that is reached without a deposit being made, then all the money already in the contract is refunded. In this case, that is simply the end of the contract.
+There is a timeout of `3600000` miliseconds (1h) on making the deposit; if that is reached without a deposit being made, then all the money already in the contract is refunded. In this case, that is simply the end of the contract.
 
 
 === Definitions
@@ -156,9 +156,9 @@ ____
 Comment on the choice of timeout values, and look at alternatives. 
 
 For
-example, what would happen if the timeout of `+40+` on the `+When+` were 
-to be replaced by `+60+`, and vice versa? Would it be sensible to have the same timeout, of 
-`+100+` say, on each `When`? If not, why not?
+example, what would happen if the timeout of `+14400000+` (4h) on the `+When+` were 
+to be replaced by `+21600000+` (6h), and vice versa? Would it be sensible to have the same timeout, of 
+`+36000000+` (10h) say, on each `When`? If not, why not?
 ____
 
 This example has shown many of the ingredients of the Marlowe contract

--- a/docs/tutorial-v3.0/marlowe-data.adoc
+++ b/docs/tutorial-v3.0/marlowe-data.adoc
@@ -31,12 +31,12 @@ type Party  = PubKey
 ----
 However, Haskell allows us to present and read in these values more concisely (by declaring a custom instance of `Show` and using _overloaded strings_) so that these can be input and read as `"alice"`, `"bob"` etc. Because `Party` is a synonym for `PubKey`, the same applies to parties to contracts. 
 
-Slot numbers and amounts of money are treated in a similar way; with the same show/overload approach they will appear in contracts as numbers:
+POSIXTimes are numbers and amounts of money are treated in a similar way; with the same show/overload approach they will appear in contracts as numbers:
 
 [source,haskell]
 ----
-data Slot    = Slot Integer
-type Timeout = Slot
+data POSIXTime = POSIXTime Integer
+type Timeout   = POSIXTime
 
 data Ada     = Lovelace Integer 
 type Money   = Ada
@@ -84,15 +84,15 @@ data Value = AvailableMoney AccountId
            | AddValue Value Value
            | SubValue Value Value
            | ChoiceValue ChoiceId Value
-           | SlotIntervalStart
-           | SlotIntervalEnd
+           | TimeIntervalStart
+           | TimeIntervalEnd
            | UseValue ValueId
 ----
 The different kinds of values – all of which are `Integer` – are pretty much self explanatory, but for completeness we have
 
 * Lookup of the value in an account `AvailableMoney`, made in a choice `ChoiceValue` and in an identifier that has already been defined  `UseValue`.
 * Arithmetic constants and operators.
-* The start and end of the current _slot interval_; see below for further discussion of this.
+* The start and end of the current _time interval_; see below for further discussion of this.
 
 Next we have observations 
 
@@ -148,7 +148,7 @@ where the types are defined like this:
 [source,haskell]
 ----
 data TransactionInput = TransactionInput
-    { txInterval :: SlotInterval
+    { txInterval :: TimeInterval
     , txInputs   :: [Input] }
 
 data TransactionOutput =
@@ -161,25 +161,25 @@ data TransactionOutput =
 ----
 The notation used here adds field names to the arguments of the constructors, giving selectors for the data as well as making in clearer the purpose of each field.
 
-The `TransactionInput` type has two components: the `SlotInterval` in which it can validly be added to the blockchain, and an ordered sequence of `Input` values to be processed in that transaction.
+The `TransactionInput` type has two components: the `TimeInterval` in which it can validly be added to the blockchain, and an ordered sequence of `Input` values to be processed in that transaction.
 
 A `TransactionOutput` value has four components: the last two are the updated `State` and `Contract`, while the second gives a ordered sequence of `Payments` produced by the transaction. The first component contains a list of any warnings produced by processing the transaction.
 
-=== Slot ranges
+=== Time ranges
 
-This is part of the architecture of Cardano/Plutus, which acknowledges that it is not possible to predict precisely in which slot a particular transaction will be processed. Transactions are therefore given a _slot interval_ in which they are expected to be processed, and this carries over to Marlowe: each step of a Marlowe contract is processed in the context of a range of slots.
+This is part of the architecture of Cardano/Plutus, which acknowledges that it is not possible to predict precisely in which time a particular transaction will be processed. Transactions are therefore given a _time interval_ in which they are expected to be processed, and this carries over to Marlowe: each step of a Marlowe contract is processed in the context of an interval of time.
 [source,haskell]
 ----
-data Slot         = Slot Integer 
-data SlotInterval = SlotInterval Slot Slot
+data POSIXTime    = POSIXTime Integer 
+data TimeInterval = TimeInterval POSIXTime POSIXTime
 
-ivFrom, ivTo :: SlotInterval -> Slot
-ivFrom (SlotInterval from _) = from
-ivTo   (SlotInterval _ to)   = to
+ivFrom, ivTo :: TimeInterval -> POSIXTime
+ivFrom (TimeInterval from _) = from
+ivTo   (TimeInterval _ to)   = to
 ----
-How does this affect the processing of a Marlowe contract? Each step is processed relative to a slot interval, and the current slot value needs to lie within that interval. 
+How does this affect the processing of a Marlowe contract? Each step is processed relative to a time interval, and the current time needs to lie within that interval. 
 
-The endpoints of the interval are accessible as the values `SlotIntervalStart` and `SlotIntervalEnd`, and these can be used in observations. Timeouts need to be processed _unambiguously_, so that _all values in the slot interval_ have to either have exceeded the timeout for it to take effect, or fall before the timeout, for normal execution to take effect. In other words, the timeout value needs to either be less or equal than `SlotIntervalStart` (in order for the timeout to take effect) or be strictly greater than `SlotIntervalEnd` (for normal execution to take place).
+The endpoints of the interval are accessible as the values `TimeIntervalStart` and `TimeIntervalEnd`, and these can be used in observations. Timeouts need to be processed _unambiguously_, so that _instants in the time interval_ have to either have exceeded the timeout for it to take effect, or fall before the timeout, for normal execution to take effect. In other words, the timeout value needs to either be less or equal than `TimeIntervalStart` (in order for the timeout to take effect) or be strictly greater than `TimeIntervalEnd` (for normal execution to take place).
 
 ==== Notes
 
@@ -189,9 +189,6 @@ infrastructure in which it is run.
 * It is assumed that cryptographic functions and operations are provided
 by a layer external to Marlowe, and so they need not be modelled
 explicitly.
-* We assume that time is ``coarse grained'' and measured by block or
-slot number, so that, in particular, timeouts are delimited using
-block/slot numbers.
 * Making a deposit is not something that a contract can perform;
 rather, it can request that a deposit is made, but that then has to
 be established externally: hence the input of (a collection of) deposits for

--- a/docs/tutorial-v3.0/marlowe-model.adoc
+++ b/docs/tutorial-v3.0/marlowe-model.adoc
@@ -24,9 +24,9 @@ In executing a contract we need to keep track of the _current contract_: after m
 
 While Marlowe is designed to work with blockchains in general,footnote:[Indeed, Marlowe could be modified to run off blockchain, or to work on a permissioned blockchain, too.] some details of how it interacts with the blockchain are relevant when describing the semantics and implementation of Marlowe.
 
-A UTxO-based blockchain is a chain of _blocks_, each of which contains a collection of transactions. Each _transaction_ has a set of inputs and outputs, and the blockchain is built by linking _unspent transaction outputs_ (UTxO) to the inputs of a new transaction. At most one block can be generated in each _slot_, which are 20 seconds long. 
+A UTxO-based blockchain is a chain of _blocks_, each of which contains a collection of transactions. Each _transaction_ has a set of inputs and outputs, and the blockchain is built by linking _unspent transaction outputs_ (UTxO) to the inputs of a new transaction.
 
-The mechanisms by which these blocks are generated, and by whom, are not relevant here, but contracts will be expressed in terms of _slot numbers_, counting from the starting (“genesis”) block of the blockchain.
+The mechanisms by which these blocks are generated, and by whom, are not relevant here, and contracts will be expressed in terms of _POSIX milliseconds_, counting from the epoch (1st of January of 1970).
 
 ==== UTxO and wallets
 
@@ -36,7 +36,7 @@ It is through their wallets that users are able to interact with smart contracts
 
 === Executing a Marlowe contract
 
-At each slot, a running Marlowe contract will receive a list of inputs in order. The contract is executed by evaluating it _step by step_ until it cannot be changed any further without processing any input, a condition that we call being _quiescent_. The first input is then processed, and then the contract is single stepped again until quiescence, and this process is repeated until all the inputs are processed. At each step the current contact and the state will change, some input may be processed, and payments made.
+At each transaction, a running Marlowe contract will receive a list of inputs in order. The contract is executed by evaluating it _step by step_ until it cannot be changed any further without processing any input, a condition that we call being _quiescent_. The first input is then processed, and then the contract is single stepped again until quiescence, and this process is repeated until all the inputs are processed. At each step the current contact and the state will change, some input may be processed, and payments made.
 
 Putting this together gives us a _transaction_, as shown in the diagram below, and this information is added to the blockchain. What we do next is to describe in detail what Marlowe contracts look like, and how they are evaluated step by step.
 

--- a/docs/tutorial-v3.0/marlowe-plutus.adoc
+++ b/docs/tutorial-v3.0/marlowe-plutus.adoc
@@ -105,10 +105,10 @@ We then evaluate the continuation contract and its state, using the
 
 [source,haskell]
 ----
-eval :: Input → Slot → Ada → Ada → State → Contract → (State,Contract,Bool)
+eval :: Input → POSIXTime → Ada → Ada → State → Contract → (State,Contract,Bool)
 ----
 
-using the current slot number and at the same time checking that the
+using the current time and at the same time checking that the
 input makes sense and that payments are within committed bounds; if the
 input is valid then it returns the new `+State+` and `+Contract+` and
 the Boolean `+True+`; otherwise it returns the current `+State+` and

--- a/docs/tutorial-v3.0/marlowe-step-by-step.adoc
+++ b/docs/tutorial-v3.0/marlowe-step-by-step.adoc
@@ -15,7 +15,7 @@ A refund contract `Refund` will provide refunds to the owners of accounts that c
 Before discussing other forms of contracts, we need to describe values, observations and actions.
 
 === Values, observations and actions
-*Values* include some quantities that change with time, including “the current slot number”,footnote:[The presentation here is a simplification of the concrete implementation, in which transactions are associated with a slot interval during which it is valid to add them to the blockchain.The reason for this is that in general it is difficult to predict the precise slot in which a transaction will be accepted for inclusion on the blockchain; it is therefore more robust to specify an interval in which the transaction should be accepted. The view presented here is a simplification in that effectively we consider only intervals of length one.  So, a Marlowe contract is able to access the upper and lower bounds on the current slot interval, rather than the specific current slot value. Executing a contract can, in some circumstances, lead to an “ambiguous slot interval error”, but we do not cover that any further here.] “the current balance of an account (in Lovelace)”, and any choices that have already been made; we call these _volatile_ values. Values can also be combined using addition, subtraction and negation.
+*Values* include some quantities that change with time, including “the current time”,footnote:[The presentation here is a simplification of the concrete implementation, in which transactions are associated with a time interval during which it is valid to add them to the blockchain. The reason for this is that in general it is not possible to predict the precise time in which a transaction will be accepted for inclusion on the blockchain; it is therefore more robust to specify an interval in which the transaction should be accepted. The view presented here is a simplification in that effectively we consider only intervals of length one. So, a Marlowe contract is able to access the upper and lower bounds on the current time interval, rather than the specific current time. Executing a contract can, in some circumstances, lead to an “ambiguous time interval error”, but we do not cover that any further here.] “the current balance of an account (in Lovelace)”, and any choices that have already been made; we call these _volatile_ values. Values can also be combined using addition, subtraction and negation.
 
 *Observations* are Boolean values derived by comparing values, and can be combined using the standard Boolean operators. It is also possible to observe whether any choice has been made (for a particular identified choice). 
 
@@ -29,16 +29,16 @@ Observations will have a value at every step of execution. On the other hand, *a
 The conditional `If obs cont1 cont2` will continue as `cont1` or `cont2`, depending on the Boolean value of the observation `obs` when this construct is executed. 
 
 === When
-This is the most complex constructor for contracts, with the form `When cases timeout cont`. It is a contract that is _triggered on actions_, which may or may not happen at any particular slot: what happens when various actions happen is described by the _cases_ in the contract. 
+This is the most complex constructor for contracts, with the form `When cases timeout cont`. It is a contract that is _triggered on actions_, which may or may not happen at any particular time: what happens when various actions happen is described by the _cases_ in the contract. 
 
 In the contract `When cases timeout cont`, the list `cases` contains a collection of cases. Each case has the form `Case ac co` where `ac` is an action and `co` a continuation (another contract). When a particular action, e.g. `ac`, happens, the state is updated accordingly and the contract will continue as the corresponding continuation `co`.
 
-In order to make sure that the contract makes progress eventually, the contract  `When cases timeout cont` will continue as `cont` once the `timeout`, a slot number, is reached.
+In order to make sure that the contract makes progress eventually, the contract  `When cases timeout cont` will continue as `cont` once the `timeout`, represented as a POSIX millisecond, is reached.
 
 === Let
 A let contract `Let id val cont` allows a contract to _name a value_ using an identifier. In this case, the expression `val` is evaluated, and stored with the name `id`. The contract then continues as `cont`. 
 
-As well as allowing us to use abbreviations, this mechanism also means that we can capture and save volatile values that might be changing with time, e.g. the current price of oil, or the current slot number, at a particular point in the execution of the contract, to be used later on in contract execution. 
+As well as allowing us to use abbreviations, this mechanism also means that we can capture and save volatile values that might be changing with time, e.g. the current price of oil, or the current time, at a particular point in the execution of the contract, to be used later on in contract execution. 
 
 ==== link:./marlowe-model.adoc[Prev] link:./README.adoc[Up] link:./marlowe-data.adoc[Next]
 

--- a/docs/tutorial-v3.0/using-marlowe.adoc
+++ b/docs/tutorial-v3.0/using-marlowe.adoc
@@ -29,7 +29,7 @@ where the types are defined like this:
 [source,haskell]
 ----
 data TransactionInput = TransactionInput
-    { txInterval :: SlotInterval
+    { txInterval :: TimeInterval
     , txInputs   :: [Input] }
 
 data TransactionOutput =
@@ -47,13 +47,13 @@ and `States` are defined like this, with a helper function to define an initiall
 data State = State { accounts :: Map AccountId Money
                    , choices  :: Map ChoiceId ChosenNum
                    , boundValues :: Map ValueId Integer
-                   , minSlot :: Slot }
+                   , minTime :: POSIXTime }
 
-emptyState :: Slot -> State
-emptyState sn = State { accounts = Map.empty
+emptyState :: POSIXTime -> State
+emptyState st = State { accounts = Map.empty
                       , choices = Map.empty
                       , boundValues = Map.empty
-                      , minSlot = sn }
+                      , minTime = st }
 ----
 
 
@@ -72,10 +72,10 @@ to make local bindings:
 Prelude> :set -XOverloadedStrings
 Prelude> :l Language/Marlowe/Examples/EscrowSimpleV2.hs 
  ...
-*Lang...V2> let (TransactionOutput txWarn1 txPay1 state1 con1) = computeTransaction (TransactionInput (SlotInterval 0 0) [IDeposit "alice" "alice" 450]) (emptyState 0) contract
+*Lang...V2> let (TransactionOutput txWarn1 txPay1 state1 con1) = computeTransaction (TransactionInput (TimeInterval 0 0) [IDeposit "alice" "alice" 450]) (emptyState 0) contract
 ----
 
-In doing this we have pattern matched the output of an application of `computeTransaction`, which takes three inputs: the second is an initial state (at slot number 0) and the third is the initial escrow contract. The first is a `TransactionInput` which contains a `SlotInterval` – here `SlotInterval 0 0` – and a deposit of 450 Lovelace from `"alice"` into her account `"alice"` namely `IDeposit "alice" "alice" 450`.
+In doing this, we have pattern matched the output of an application of `computeTransaction`, which takes three inputs: the second is an initial state (at millisecond 0, the epoch) and the third is the initial escrow contract. The first is a `TransactionInput` which contains a `TimeInterval` – here `TimeInterval 0 0` – and a deposit of 450 Lovelace from `"alice"` into her account `"alice"` namely `IDeposit "alice" "alice" 450`.
 
 NOTE: If you want to try this for yourself in ghci, you can copy and paste from the code examples: they are in horizontally scrolling windows.
 
@@ -88,7 +88,7 @@ The output is matched with `TransactionOutput txWarn1 txPay1 state1 con1` so tha
 *Lang...V2> txPay1
 []
 *Lang...V2> state1
-State {accounts = fromList [(AccountId 0 "alice",450)], choices = fromList [], boundValues = fromList [], minSlot = 0}
+State {accounts = fromList [(AccountId 0 "alice",450)], choices = fromList [], boundValues = fromList [], minTime = 0}
 *Lang...V2> con1
 When [Case (Choice (ChoiceId "choice" "alice") [Bound 0 1]) 
  ...
@@ -99,13 +99,13 @@ In the next state the contract is waiting for input, and if both Alice and Bob a
 
 [source%wrap,haskell]
 ----
-*Lang...V2> let (TransactionOutput txWarn2 txPay2 state2 con2) = computeTransaction (TransactionInput (SlotInterval 0 0) [IChoice (ChoiceId "choice" "alice") 0, IChoice (ChoiceId "choice" "bob") 0]) state1 con1
+*Lang...V2> let (TransactionOutput txWarn2 txPay2 state2 con2) = computeTransaction (TransactionInput (TimeInterval 0 0) [IChoice (ChoiceId "choice" "alice") 0, IChoice (ChoiceId "choice" "bob") 0]) state1 con1
 *Lang...V2> txPay2
 [Payment "bob" 450]
 *Lang...V2> con2
 Refund
 *Lang...V2> state2
-State {accounts = fromList [], choices = fromList [(ChoiceId "choice" "alice",0),(ChoiceId "choice" "bob",0)], boundValues = fromList [], minSlot = 0}
+State {accounts = fromList [], choices = fromList [(ChoiceId "choice" "alice",0),(ChoiceId "choice" "bob",0)], boundValues = fromList [], minTime = 0}
 ----
 
 An alternative way of doing this is to add these definitions to a
@@ -125,11 +125,11 @@ An alternative execution of the contract is given by
 
 [source,haskell]
 ----
-*Lang...V2> let (TransactionOutput txWarn2 txPay2 state2 con2) = computeTransaction (TransactionInput (SlotInterval 0 0) [IChoice (ChoiceId "choice" "alice") 0, IChoice (ChoiceId "choice" "bob") 1]) state1 con1
+*Lang...V2> let (TransactionOutput txWarn2 txPay2 state2 con2) = computeTransaction (TransactionInput (TimeInterval 0 0) [IChoice (ChoiceId "choice" "alice") 0, IChoice (ChoiceId "choice" "bob") 1]) state1 con1
 *Lang...V2> con2
 When [Case (Choice (ChoiceId "choice" "carol") [Bound 1 1]) Refund,Case (Choice (ChoiceId "choice" "carol") [Bound 0 0]) (Pay (AccountId 0 "alice") (Party "bob") (Constant 450) Refund)] 100 Refund
 *Lang...V2> state2
-State {accounts = fromList [(AccountId 0 "alice",450)], choices = fromList [(ChoiceId "choice" "alice",0),(ChoiceId "choice" "bob",1)], boundValues = fromList [] , minSlot = 0}
+State {accounts = fromList [(AccountId 0 "alice",450)], choices = fromList [(ChoiceId "choice" "alice",0),(ChoiceId "choice" "bob",1)], boundValues = fromList [] , minTime = 0}
 ----
 
 This shows that we're now in a contract where the choice is up to Carol, and that there is still the 450 Lovelace in the `"alice"` account.
@@ -138,13 +138,13 @@ This shows that we're now in a contract where the choice is up to Carol, and tha
 
 [source,haskell]
 ----
-*Lang...V2> let (TransactionOutput txWarn3 txPay3 state3 con3) = computeTransaction  (TransactionInput (SlotInterval 0 0) [IChoice (ChoiceId "choice" "carol") 1]) state2 con2
+*Lang...V2> let (TransactionOutput txWarn3 txPay3 state3 con3) = computeTransaction  (TransactionInput (TimeInterval 0 0) [IChoice (ChoiceId "choice" "carol") 1]) state2 con2
 *Lang...V2> txPay3
 [Payment "alice" 450]
 *Lang...V2> con3
 Refund
 *Lang...V2> state3
-State {accounts = fromList [], choices = fromList [(ChoiceId "choice" "alice",0), (ChoiceId "choice" "bob",1),(ChoiceId "choice" "carol",1)], boundValues = fromList [], minSlot = 0}
+State {accounts = fromList [], choices = fromList [(ChoiceId "choice" "alice",0), (ChoiceId "choice" "bob",1),(ChoiceId "choice" "carol",1)], boundValues = fromList [], minTime = 0}
 ----
 
 So now the contract is ready to `Refund`, but it is clear from `state3` that there are no accounts containing non-zero balances, and so the contract is terminated.

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -17,7 +17,7 @@ Modify the Haskell escrow contract to a “Bulgarian” variant in which Bob has
 
 The challenge is to write a Marlowe contract that models payments for a utility, such as a mobile phone.
 
-The contract models the fact that you make regular payments to the company, every 3 hours. These payments are specified by the company, and you have 3 hours in which to pay. To start with, model the situation where the payment is 40 Ada each month.
+The contract models the fact that you make regular payments to the company, every 3 hours. These payments are specified by the company, and you have 1 hour in which to pay. To start with, model the situation where the payment is 40 Ada each month.
 
 At the start of the contract you make a deposit, say 150 Lovelace, and during the year, if you do not pay on time the company keeps the full deposit. If you have paid regularly, at the end of the contract  the deposit is paid back to you.
 

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -17,13 +17,13 @@ Modify the Haskell escrow contract to a “Bulgarian” variant in which Bob has
 
 The challenge is to write a Marlowe contract that models payments for a utility, such as a mobile phone.
 
-The contract models the fact that you make regular payments to the company, every 30 slots. These payments are specified by the company, and you have 10 slots in which to pay. To start with, model the situation where the payment is 40 Ada each month.
+The contract models the fact that you make regular payments to the company, every 3 hours. These payments are specified by the company, and you have 3 hours in which to pay. To start with, model the situation where the payment is 40 Ada each month.
 
 At the start of the contract you make a deposit, say 150 Lovelace, and during the year, if you do not pay on time the company keeps the full deposit. If you have paid regularly, at the end of the contract  the deposit is paid back to you.
 
 ### Blockly and the Marlowe Playground
 
-If you are writing the contract in Blockly, model a contract that includes two cycles of 30 slots.
+If you are writing the contract in Blockly, model a contract that includes two cycles of 3 hours.
 
 If you are writing the contract in Haskell using the Marlowe Playground, write a version that is parameterised over the number of cycles.
 
@@ -32,8 +32,8 @@ If you are writing the contract in Haskell using the Marlowe Playground, write a
 You can try to add these variants, either one at a time, or in combination.
 
 - Model the situation where the company can specify (using a choice `Action`) how much to pay at the time of payment rather than having it fixed in advance in the contract.
-- You can cancel the subscription giving 30 slots notice; on doing this you can recover half the deposit.
-- The company can increase the fixed fee by a given amount once only,  giving 20 slots notice. If this is done, then you can withdraw from the contract without losing your deposit.
+- You can cancel the subscription giving 3 hours notice; on doing this you can recover half the deposit.
+- The company can increase the fixed fee by a given amount once only, giving 2 hours notice. If this is done, then you can withdraw from the contract without losing your deposit.
 
 ### Analysis
 

--- a/isabelle/Core/MoneyPreservation.thy
+++ b/isabelle/Core/MoneyPreservation.thy
@@ -21,7 +21,7 @@ fun moneyInReduceStepResult :: "State \<Rightarrow> ReduceStepResult \<Rightarro
 "moneyInReduceStepResult _ (Reduced _ reduceEffect state _) =
    moneyInReduceEffect reduceEffect + moneyInState state" |
 "moneyInReduceStepResult state NotReduced = moneyInState state" |
-"moneyInReduceStepResult state AmbiguousSlotIntervalReductionError = moneyInState state"
+"moneyInReduceStepResult state AmbiguousTimeIntervalReductionError = moneyInState state"
 
 fun moneyInRefundOneResult :: "Accounts \<Rightarrow>
                                ((Party \<times> Token \<times> Money) \<times> Accounts) option \<Rightarrow> int" where
@@ -43,7 +43,7 @@ lemma moneyInPayments_works_on_rev : "moneyInPayments payments = moneyInPayments
 
 fun moneyInReduceResult :: "Payment list \<Rightarrow> State \<Rightarrow> ReduceResult \<Rightarrow> int" where
 "moneyInReduceResult pa sta (ContractQuiescent newReduced wa newPa newSta cont) = moneyInState newSta + moneyInPayments newPa" |
-"moneyInReduceResult pa sta RRAmbiguousSlotIntervalError = moneyInState sta + moneyInPayments pa"
+"moneyInReduceResult pa sta RRAmbiguousTimeIntervalError = moneyInState sta + moneyInPayments pa"
 
 fun moneyInInput :: "Input \<Rightarrow> int" where
 "moneyInInput (IDeposit accId tok party money) = max 0 money" |
@@ -66,7 +66,7 @@ fun moneyInApplyAllResult :: "State \<Rightarrow> Input list \<Rightarrow> Payme
   moneyInState newSta + moneyInPayments newPa" |
 "moneyInApplyAllResult state inps pa ApplyAllNoMatchError =
   moneyInState state + moneyInInputs inps + moneyInPayments pa" |
-"moneyInApplyAllResult state inps pa ApplyAllAmbiguousSlotIntervalError =
+"moneyInApplyAllResult state inps pa ApplyAllAmbiguousTimeIntervalError =
   moneyInState state + moneyInInputs inps + moneyInPayments pa"
 
 fun moneyInTransactionOutput :: "State \<Rightarrow> Input list \<Rightarrow> TransactionOutput \<Rightarrow> int" where
@@ -381,9 +381,9 @@ lemma reduceContractStep_preserves_money :
     apply simp
   subgoal for cases timeout contr
     apply (simp only:reduceContractStep.simps)
-    apply (cases "snd (slotInterval env) < timeout")
+    apply (cases "snd (timeInterval env) < timeout")
     apply (simp add: case_prod_beta')
-    apply (cases "timeout \<le> fst (slotInterval env)")
+    apply (cases "timeout \<le> fst (timeInterval env)")
     apply (simp add: case_prod_beta')
     by (simp add: case_prod_beta')
   subgoal for valId val cont

--- a/isabelle/Core/SemanticsTypes.thy
+++ b/isabelle/Core/SemanticsTypes.thy
@@ -3,7 +3,7 @@ imports Main Util.MList Util.SList ListTools "HOL-Library.Product_Lexorder" Util
 begin
 
 
-type_synonym Slot = int
+type_synonym POSIXTime = int
 
 type_synonym PubKey = ByteString
 
@@ -13,7 +13,7 @@ type_synonym TokenName = ByteString
 
 type_synonym ChoiceName = ByteString
 type_synonym NumAccount = int
-type_synonym Timeout = Slot
+type_synonym Timeout = POSIXTime
 type_synonym Money = Ada
 type_synonym ChosenNum = int
 
@@ -330,8 +330,8 @@ datatype Value = AvailableMoney AccountId Token
                | MulValue Value Value
                | DivValue Value Value
                | ChoiceValue ChoiceId
-               | SlotIntervalStart
-               | SlotIntervalEnd
+               | TimeIntervalStart
+               | TimeIntervalEnd
                | UseValue ValueId
                | Cond Observation Value Value
 and Observation = AndObs Observation Observation
@@ -346,7 +346,7 @@ and Observation = AndObs Observation Observation
                      | TrueObs
                      | FalseObs
 
-type_synonym SlotInterval = "Slot \<times> Slot"
+type_synonym TimeInterval = "POSIXTime \<times> POSIXTime"
 type_synonym Bound = "int \<times> int"
 
 fun inBounds :: "ChosenNum \<Rightarrow> Bound list \<Rightarrow> bool" where
@@ -372,22 +372,22 @@ type_synonym Accounts = "((AccountId \<times> Token) \<times> Money) list"
 record State = accounts :: Accounts
                choices :: "(ChoiceId \<times> ChosenNum) list"
                boundValues :: "(ValueId \<times> int) list"
-               minSlot :: Slot
+               minTime :: POSIXTime
 
 fun valid_state :: "State \<Rightarrow> bool" where
 "valid_state state = (valid_map (accounts state)
                      \<and> valid_map (choices state)
                      \<and> valid_map (boundValues state))"
 
-record Environment = slotInterval :: SlotInterval
+record Environment = timeInterval :: TimeInterval
 
 datatype Input = IDeposit AccountId Party Token Money
                | IChoice ChoiceId ChosenNum
                | INotify
 
-(* Processing of slot interval *)
-datatype IntervalError = InvalidInterval SlotInterval
-                       | IntervalInPastError Slot SlotInterval
+(* Processing of time interval *)
+datatype IntervalError = InvalidInterval TimeInterval
+                       | IntervalInPastError POSIXTime TimeInterval
 
 datatype IntervalResult = IntervalTrimmed Environment State
                         | IntervalError IntervalError

--- a/isabelle/Core/SingleInputTransactions.thy
+++ b/isabelle/Core/SingleInputTransactions.thy
@@ -6,7 +6,7 @@ begin
 
 declare [[ smt_timeout = 300 ]]
 
-fun inputsToTransactions :: "SlotInterval \<Rightarrow> Input list \<Rightarrow> Transaction list" where
+fun inputsToTransactions :: "TimeInterval \<Rightarrow> Input list \<Rightarrow> Transaction list" where
 "inputsToTransactions si Nil = Cons \<lparr> interval = si
                                     , inputs = Nil \<rparr> Nil" |
 "inputsToTransactions si (Cons inp1 Nil) = Cons \<lparr> interval = si
@@ -394,43 +394,43 @@ lemma computeAllPrefix2:
   by simp
 
 lemma fixIntervalOnlySummary :
-  "minSlot state = low \<Longrightarrow> low \<le> high \<Longrightarrow>
-   IntervalTrimmed \<lparr> slotInterval = (low, high) \<rparr> state = fixInterval (low, high) state"
+  "minTime state = low \<Longrightarrow> low \<le> high \<Longrightarrow>
+   IntervalTrimmed \<lparr> timeInterval = (low, high) \<rparr> state = fixInterval (low, high) state"
   by simp
 
 lemma fixIntervalOnlySummary2 :
-  "fixInterval (low, high) state = IntervalTrimmed \<lparr> slotInterval = (nlow, nhigh) \<rparr> nstate \<Longrightarrow>
-   nlow = minSlot nstate \<and> low \<le> high"
+  "fixInterval (low, high) state = IntervalTrimmed \<lparr> timeInterval = (nlow, nhigh) \<rparr> nstate \<Longrightarrow>
+   nlow = minTime nstate \<and> low \<le> high"
   apply (cases "high < low")
   apply simp
-  apply (cases "high < minSlot state")
+  apply (cases "high < minTime state")
   by (auto simp add:Let_def)
 
 lemma fixIntervalChecksInterval :
-  "fixInterval inte sta1 = IntervalTrimmed \<lparr>slotInterval = (low, high)\<rparr> sta2 \<Longrightarrow>
+  "fixInterval inte sta1 = IntervalTrimmed \<lparr>timeInterval = (low, high)\<rparr> sta2 \<Longrightarrow>
    low \<le> high"
   apply (cases inte)
   apply (simp add:Let_def)
   subgoal for low1 high1
     apply (cases "high1 < low1")
     apply simp_all
-    apply (cases "high1 < minSlot sta1")
+    apply (cases "high1 < minTime sta1")
     apply simp_all
     by linarith
   done
 
 lemma fixIntervalIdempotentOnInterval :
-  "minSlot sta4 = minSlot sta2 \<Longrightarrow>
-   fixInterval (low1, high1) sta1 = IntervalTrimmed \<lparr>slotInterval = (low, high)\<rparr> sta2 \<Longrightarrow>
+  "minTime sta4 = minTime sta2 \<Longrightarrow>
+   fixInterval (low1, high1) sta1 = IntervalTrimmed \<lparr>timeInterval = (low, high)\<rparr> sta2 \<Longrightarrow>
    fixInterval (low1, high1) sta4 = fixInterval (low, high) sta4"
   apply (cases "high1 < low1")
   apply simp
-  apply (cases "high1 < minSlot sta1")
+  apply (cases "high1 < minTime sta1")
   by (auto simp add:Let_def)
 
-lemma reductionContractStep_preserves_minSlot :
+lemma reductionContractStep_preserves_minTime :
   "reduceContractStep env state contract = Reduced wa ef sta2 cont2 \<Longrightarrow>
-   minSlot state = minSlot sta2"
+   minTime state = minTime sta2"
   apply (cases contract)
   apply (auto split:option.splits simp add:Let_def)
   subgoal for x21 x22 x23 x24 x25
@@ -441,23 +441,23 @@ lemma reductionContractStep_preserves_minSlot :
   apply (auto split:prod.splits simp add:Let_def)
   by (metis ReduceStepResult.distinct(1) ReduceStepResult.distinct(3) ReduceStepResult.inject)
 
-lemma reductionLoop_preserves_minSlot :
-  "reductionLoop reducedBefore env sta con wa pa = ContractQuiescent reducedAfter reduceWarns pays sta2 con2 \<Longrightarrow> minSlot sta = minSlot sta2"
+lemma reductionLoop_preserves_minTime :
+  "reductionLoop reducedBefore env sta con wa pa = ContractQuiescent reducedAfter reduceWarns pays sta2 con2 \<Longrightarrow> minTime sta = minTime sta2"
   apply (induction reducedBefore env sta con wa pa arbitrary:reducedAfter reduceWarns pays sta2 con2 rule:reductionLoop.induct)
   subgoal for env state contract warnings payments reduceWarns pays sta2 con2
     apply (simp only:reductionLoop.simps[of env state contract warnings payments])
     apply (auto split:ReduceStepResult.splits simp del:reductionLoop.simps)
-    using reductionContractStep_preserves_minSlot by auto
+    using reductionContractStep_preserves_minTime by auto
   done
 
-lemma reduceContractUntilQuiescent_preserves_minSlot :
-  "reduceContractUntilQuiescent env sta con = ContractQuiescent reducedAfter reduceWarns pays sta2 con2 \<Longrightarrow> minSlot sta = minSlot sta2"
+lemma reduceContractUntilQuiescent_preserves_minTime :
+  "reduceContractUntilQuiescent env sta con = ContractQuiescent reducedAfter reduceWarns pays sta2 con2 \<Longrightarrow> minTime sta = minTime sta2"
   apply (simp only:reduceContractUntilQuiescent.simps)
-  by (simp add: reductionLoop_preserves_minSlot)
+  by (simp add: reductionLoop_preserves_minTime)
 
-lemma applyCases_preserves_minSlot :
+lemma applyCases_preserves_minTime :
   "applyCases env curState head x41 = Applied applyWarn newState newCont \<Longrightarrow>
-   minSlot curState = minSlot newState"
+   minTime curState = minTime newState"
   apply (induction env curState head x41 arbitrary:applyWarn newCont newState rule:applyCases.induct)
   subgoal for env state accId1 party1 tok1 amount accId2 party2 tok2 val cont rest applyWarn newCont newState
     apply (cases "accId1 = accId2 \<and> party1 = party2 \<and> tok1 = tok2 \<and> amount = evalValue env state val")
@@ -470,20 +470,20 @@ lemma applyCases_preserves_minSlot :
     by auto
   by auto
 
-lemma applyInput_preserves_minSlot :
-  "applyInput env curState head cont = Applied applyWarn newState newCont \<Longrightarrow> minSlot curState = minSlot newState"
+lemma applyInput_preserves_minTime :
+  "applyInput env curState head cont = Applied applyWarn newState newCont \<Longrightarrow> minTime curState = minTime newState"
   apply (cases cont)
-  by (auto simp add:applyCases_preserves_minSlot)
+  by (auto simp add:applyCases_preserves_minTime)
 
-lemma applyAllLoop_preserves_minSlot :
-  "applyAllLoop reducedBefore env sta con inp wa pa = ApplyAllSuccess reducedAfter wa2 pa2 sta2 con2 \<Longrightarrow> minSlot sta = minSlot sta2"
+lemma applyAllLoop_preserves_minTime :
+  "applyAllLoop reducedBefore env sta con inp wa pa = ApplyAllSuccess reducedAfter wa2 pa2 sta2 con2 \<Longrightarrow> minTime sta = minTime sta2"
   apply (induction inp arbitrary:reducedBefore env sta con wa pa reducedAfter wa2 pa2 sta2 con2)
   subgoal for reducedBefore env sta con wa pa reducedAfter wa2 pa2 sta2 con2
     apply (simp only:applyAllLoop.simps[of reducedBefore env sta con "[]" wa pa])
     apply (cases "reduceContractUntilQuiescent env sta con")
     subgoal for reduceWarns pays curState cont
       apply (simp del:reduceContractUntilQuiescent.simps)
-      using reduceContractUntilQuiescent_preserves_minSlot by blast
+      using reduceContractUntilQuiescent_preserves_minTime by blast
       apply (simp del:reduceContractUntilQuiescent.simps)
     done
   subgoal for head tail reducedBefore env sta con wa pa reducedAfter wa2 pa2 sta2 con2
@@ -492,37 +492,37 @@ lemma applyAllLoop_preserves_minSlot :
       subgoal for reducedAfter reduceWarns pays curState cont
         apply (cases "applyInput env curState head cont")
         subgoal for applyWarn newState newCont
-          by (simp add: applyInput_preserves_minSlot reduceContractUntilQuiescent_preserves_minSlot)
+          by (simp add: applyInput_preserves_minTime reduceContractUntilQuiescent_preserves_minTime)
         by simp
       by simp
     done
 
-lemma applyAllInputs_preserves_minSlot :
+lemma applyAllInputs_preserves_minTime :
   "applyAllInputs env sta con inp = ApplyAllSuccess reducedAfter wa2 pa2 sta2 con2 \<Longrightarrow>
-   minSlot sta = minSlot sta2"
+   minTime sta = minTime sta2"
   apply (simp only:applyAllInputs.simps)
-  using applyAllLoop_preserves_minSlot by blast
+  using applyAllLoop_preserves_minTime by blast
 
-lemma applyAllInputs_preserves_minSlot_rev :
+lemma applyAllInputs_preserves_minTime_rev :
    "applyAllInputs env sta con inp = ApplyAllSuccess reducedAfter wa2 pa2 sta2 con2 \<Longrightarrow>
-    minSlot sta2 = minSlot sta"
-  by (simp add: applyAllInputs_preserves_minSlot)
+    minTime sta2 = minTime sta"
+  by (simp add: applyAllInputs_preserves_minTime)
 
 lemma fixIntervalIdempotentThroughApplyAllInputs :
   "fixInterval inte sta1 = IntervalTrimmed env2 sta2 \<Longrightarrow>
    applyAllInputs env2 sta2 con3 inp1 = ApplyAllSuccess reducedAfter wa4 pa4 sta4 con4 \<Longrightarrow>
    fixInterval inte sta4 = IntervalTrimmed env2 sta4"
   apply (cases env2)
-  subgoal for slotInterval
-    apply (cases slotInterval)
+  subgoal for timeInterval
+    apply (cases timeInterval)
     subgoal for low high
       apply (simp del:fixInterval.simps applyAllInputs.simps)
       apply (subst fixIntervalOnlySummary)
-      apply (metis applyAllInputs_preserves_minSlot eq_fst_iff fixIntervalOnlySummary2)
+      apply (metis applyAllInputs_preserves_minTime eq_fst_iff fixIntervalOnlySummary2)
       using fixIntervalChecksInterval apply blast
       apply (cases inte)
       subgoal for low1 high1
-        using applyAllInputs_preserves_minSlot_rev fixIntervalIdempotentOnInterval by blast
+        using applyAllInputs_preserves_minTime_rev fixIntervalIdempotentOnInterval by blast
       done
     done
   done
@@ -561,7 +561,7 @@ lemma reductionStep_only_makes_smaller :
     apply auto[1]
   subgoal for cases timeout contract
     apply simp
-    apply (cases "slotInterval env")
+    apply (cases "timeInterval env")
     subgoal for low high
       apply simp
       apply (cases "high < timeout")
@@ -770,11 +770,11 @@ lemma fixIntervalPreservesAccounts :
   "fixInterval interv sta = IntervalTrimmed interv2 sta2 \<Longrightarrow> accounts sta = accounts sta2"
   apply (cases "sta")
   apply (cases "interv")
-  subgoal for accounts choices boundValues minSlot low high
+  subgoal for accounts choices boundValues minTime low high
     apply simp
     apply (cases "high < low")
     apply simp
-    apply (cases "high < minSlot")
+    apply (cases "high < minTime")
     by (auto simp add:Let_def)
   done
 
@@ -883,7 +883,7 @@ lemma computeTransactionStepEquivalence :
      by simp
 
 lemma applyAllInputs_prefix_error :
-  "a = ApplyAllAmbiguousSlotIntervalError \<or> a = ApplyAllNoMatchError \<Longrightarrow>
+  "a = ApplyAllAmbiguousTimeIntervalError \<or> a = ApplyAllNoMatchError \<Longrightarrow>
    applyAllInputs env fixSta txOutCont [head] = a \<Longrightarrow>
    applyAllInputs env fixSta txOutCont (head # tail) = a"
   apply (simp only:applyAllInputs.simps applyAllLoop.simps[of False env fixSta txOutCont])
@@ -956,9 +956,9 @@ lemma fixInterval_doesnt_care_about_inputs :
    fixInterval (interval \<lparr>interval = interv, inputs = inp2\<rparr>) sta = IntervalTrimmed env fixSta"
   by simp
 
-lemma fixInterval_idemp_on_same_minSlot :
+lemma fixInterval_idemp_on_same_minTime :
   "fixInterval interv sta = IntervalTrimmed env fixSta \<Longrightarrow>
-   minSlot fixSta = minSlot ista \<Longrightarrow>
+   minTime fixSta = minTime ista \<Longrightarrow>
    fixInterval interv ista = IntervalTrimmed env ista"
   apply (cases sta)
   apply (cases ista)
@@ -972,7 +972,7 @@ lemma fixInterval_idemp_after_computeTransaction :
    applyInput env curState head cont = Applied applyWarn newState cont2 \<Longrightarrow>
    reduceContractUntilQuiescent env newState cont2 = ContractQuiescent reduceReduced2 reduceWarns2 pays2 ista icont \<Longrightarrow>
    fixInterval interv ista = IntervalTrimmed env ista"
-  by (simp add: applyInput_preserves_minSlot fixInterval_idemp_on_same_minSlot reductionLoop_preserves_minSlot)
+  by (simp add: applyInput_preserves_minTime fixInterval_idemp_on_same_minTime reductionLoop_preserves_minTime)
 
 lemma applyAllLoop_independet_of_acc_error1 :
   "applyAllLoop reducedBefore env sta cont htail wa pa = ApplyAllNoMatchError \<Longrightarrow>
@@ -985,8 +985,8 @@ lemma applyAllLoop_independet_of_acc_error1 :
   done
 
 lemma applyAllLoop_independet_of_acc_error2 :
-  "applyAllLoop reducedBefore env sta cont htail wa pa = ApplyAllAmbiguousSlotIntervalError \<Longrightarrow>
-   applyAllLoop reducedBefore env sta cont htail wa2 pa2 = ApplyAllAmbiguousSlotIntervalError"
+  "applyAllLoop reducedBefore env sta cont htail wa pa = ApplyAllAmbiguousTimeIntervalError \<Longrightarrow>
+   applyAllLoop reducedBefore env sta cont htail wa2 pa2 = ApplyAllAmbiguousTimeIntervalError"
   apply (induction htail arbitrary: reducedBefore env sta cont wa pa wa2 pa2)
   apply (force split:ReduceResult.split)
   subgoal for head tail reducedBefore env sta cont wa pa wa2 pa2

--- a/isabelle/Core/Timeout.thy
+++ b/isabelle/Core/Timeout.thy
@@ -40,29 +40,29 @@ lemma reduceClose_is_Close : "reduceContractUntilQuiescent env sta Close = Contr
   using reductionLoopClose_is_Close by blast
 
 lemma timedOutReduce_only_quiescent_in_close_When :
-  "minSlot sta \<le> iniSlot \<Longrightarrow>
-   maxTimeContract (When x41 x42 x43) \<le> iniSlot \<Longrightarrow>
-   iniSlot \<le> endSlot \<Longrightarrow>
-   reduceContractStep \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> (sta\<lparr>minSlot := iniSlot\<rparr>) (When x41 x42 x43) \<noteq> NotReduced"
+  "minTime sta \<le> iniTime \<Longrightarrow>
+   maxTimeContract (When x41 x42 x43) \<le> iniTime \<Longrightarrow>
+   iniTime \<le> endTime \<Longrightarrow>
+   reduceContractStep \<lparr>timeInterval = (iniTime, endTime)\<rparr> (sta\<lparr>minTime := iniTime\<rparr>) (When x41 x42 x43) \<noteq> NotReduced"
   apply (induction x41)
   by simp_all
 
-lemma maxTimeWhen : "maxTimeContract (When x41 x42 x43) \<le> iniSlot \<Longrightarrow> x42 \<le> iniSlot"
-  apply (induction x41 arbitrary:x42 x43 iniSlot)
+lemma maxTimeWhen : "maxTimeContract (When x41 x42 x43) \<le> iniTime \<Longrightarrow> x42 \<le> iniTime"
+  apply (induction x41 arbitrary:x42 x43 iniTime)
   by auto
 
 lemma maxTimeNotAmbiguous_reduceStep :
-   "maxTimeContract cont \<le> iniSlot \<Longrightarrow>
-    iniSlot \<le> endSlot \<Longrightarrow>
-    reduceContractStep \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> state cont \<noteq> AmbiguousSlotIntervalReductionError"
+   "maxTimeContract cont \<le> iniTime \<Longrightarrow>
+    iniTime \<le> endTime \<Longrightarrow>
+    reduceContractStep \<lparr>timeInterval = (iniTime, endTime)\<rparr> state cont \<noteq> AmbiguousTimeIntervalReductionError"
   apply (cases cont)
   apply simp
   apply (auto split:option.split bool.split)
   subgoal for x21 x22 x23 x24 x25
-    apply (cases "let moneyToPay = evalValue \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> state x24 in moneyToPay \<le> 0")
+    apply (cases "let moneyToPay = evalValue \<lparr>timeInterval = (iniTime, endTime)\<rparr> state x24 in moneyToPay \<le> 0")
     apply simp
     apply simp
-    apply (cases "let moneyToPay = evalValue \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> state x24;
+    apply (cases "let moneyToPay = evalValue \<lparr>timeInterval = (iniTime, endTime)\<rparr> state x24;
                       balance = case lookup (x21, x23) (accounts state) of None \<Rightarrow> 0 | Some x \<Rightarrow> x; paidMoney = min balance moneyToPay
                   in giveMoney x21 x22 x23 paidMoney (if balance \<le> moneyToPay then MList.delete (x21, x23) (accounts state)
                                                       else MList.insert (x21, x23) (balance - paidMoney) (accounts state))")
@@ -99,12 +99,12 @@ lemma maxTimeOnlyDecreases_reduceStep :
   apply (metis ReduceStepResult.inject eq_iff maxTimeContract.simps(6) reduceContractStep.simps(5))
   by simp
 
-lemma maxTimeNotAmbiguous_reduceLoop : "maxTimeContract cont \<le> iniSlot \<Longrightarrow>
-    iniSlot \<le> endSlot \<Longrightarrow>
-    reductionLoop reduced \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> sta cont x y \<noteq> RRAmbiguousSlotIntervalError"
-  apply (induction reduced "\<lparr>slotInterval = (iniSlot, endSlot)\<rparr>" sta cont x y rule:reductionLoop.induct)
+lemma maxTimeNotAmbiguous_reduceLoop : "maxTimeContract cont \<le> iniTime \<Longrightarrow>
+    iniTime \<le> endTime \<Longrightarrow>
+    reductionLoop reduced \<lparr>timeInterval = (iniTime, endTime)\<rparr> sta cont x y \<noteq> RRAmbiguousTimeIntervalError"
+  apply (induction reduced "\<lparr>timeInterval = (iniTime, endTime)\<rparr>" sta cont x y rule:reductionLoop.induct)
   subgoal premises facts for reduced state contract warnings payments
-    apply (cases "reduceContractStep \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> state contract")
+    apply (cases "reduceContractStep \<lparr>timeInterval = (iniTime, endTime)\<rparr> state contract")
       apply (simp only:reductionLoop.simps ReduceStepResult.case)
       apply (simp only:Let_def)
       using facts(1) facts(2) facts(3) maxTimeOnlyDecreases_reduceStep apply fastforce
@@ -112,17 +112,17 @@ lemma maxTimeNotAmbiguous_reduceLoop : "maxTimeContract cont \<le> iniSlot \<Lon
       by (simp add: facts(2) facts(3) maxTimeNotAmbiguous_reduceStep)
     done
 
-lemma maxTimeNotAmbiguous : "maxTimeContract cont \<le> iniSlot \<Longrightarrow>
-       iniSlot \<le> endSlot \<Longrightarrow>
-       reduceContractUntilQuiescent \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> (sta\<lparr>minSlot := iniSlot\<rparr>) cont \<noteq> RRAmbiguousSlotIntervalError"
+lemma maxTimeNotAmbiguous : "maxTimeContract cont \<le> iniTime \<Longrightarrow>
+       iniTime \<le> endTime \<Longrightarrow>
+       reduceContractUntilQuiescent \<lparr>timeInterval = (iniTime, endTime)\<rparr> (sta\<lparr>minTime := iniTime\<rparr>) cont \<noteq> RRAmbiguousTimeIntervalError"
   using maxTimeNotAmbiguous_reduceLoop by auto
 
 
 lemma timedOutReduce_only_quiescent_in_close :
-  "minSlot sta \<le> iniSlot \<Longrightarrow>
-   maxTimeContract c \<le> iniSlot \<Longrightarrow>
-   iniSlot \<le> endSlot \<Longrightarrow>
-   reduceContractStep \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> (sta\<lparr>minSlot := iniSlot\<rparr>) c = NotReduced \<Longrightarrow> c = Close"
+  "minTime sta \<le> iniTime \<Longrightarrow>
+   maxTimeContract c \<le> iniTime \<Longrightarrow>
+   iniTime \<le> endTime \<Longrightarrow>
+   reduceContractStep \<lparr>timeInterval = (iniTime, endTime)\<rparr> (sta\<lparr>minTime := iniTime\<rparr>) c = NotReduced \<Longrightarrow> c = Close"
   apply (cases c)
   apply blast
   apply (metis reduceContractStep.simps(2) reduceContractStepPayIsQuiescent)
@@ -131,10 +131,10 @@ lemma timedOutReduce_only_quiescent_in_close :
   apply (metis ReduceStepResult.distinct(1) reduceContractStep.simps(5))
   by simp
 
-lemma timedOutReduceStep_does_not_modify_minSlot :
-  "minSlot sta = iniSlot \<Longrightarrow>
-   reduceContractStep \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> sta contract =
-   Reduced warning effect newState ncontract \<Longrightarrow> minSlot newState = iniSlot"
+lemma timedOutReduceStep_does_not_modify_minTime :
+  "minTime sta = iniTime \<Longrightarrow>
+   reduceContractStep \<lparr>timeInterval = (iniTime, endTime)\<rparr> sta contract =
+   Reduced warning effect newState ncontract \<Longrightarrow> minTime newState = iniTime"
   apply (cases contract)
     apply simp
     apply (cases "refundOne (accounts sta)")
@@ -146,20 +146,20 @@ lemma timedOutReduceStep_does_not_modify_minSlot :
           by auto
         done
       subgoal for x21 x22 x23 x24
-      apply (cases "let moneyToPay = evalValue \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> sta x24
+      apply (cases "let moneyToPay = evalValue \<lparr>timeInterval = (iniTime, endTime)\<rparr> sta x24
                     in moneyToPay \<le> 0")
       apply auto[1]
       apply simp
       apply (cases "giveMoney x21 x22 x23
            (min (case lookup (x21, x23) (accounts sta) of None \<Rightarrow> 0 | Some x \<Rightarrow> x)
-             (evalValue \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> sta x24))
+             (evalValue \<lparr>timeInterval = (iniTime, endTime)\<rparr> sta x24))
            (if (case lookup (x21, x23) (accounts sta) of None \<Rightarrow> 0 | Some x \<Rightarrow> x)
-               \<le> evalValue \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> sta x24
+               \<le> evalValue \<lparr>timeInterval = (iniTime, endTime)\<rparr> sta x24
             then MList.delete (x21, x23) (accounts sta)
             else MList.insert (x21, x23)
                   ((case lookup (x21, x23) (accounts sta) of None \<Rightarrow> 0 | Some x \<Rightarrow> x) -
                    min (case lookup (x21, x23) (accounts sta) of None \<Rightarrow> 0 | Some x \<Rightarrow> x)
-                    (evalValue \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> sta x24))
+                    (evalValue \<lparr>timeInterval = (iniTime, endTime)\<rparr> sta x24))
                   (accounts sta))")
       by (auto simp:Let_def)
       apply auto[1]
@@ -167,17 +167,17 @@ lemma timedOutReduceStep_does_not_modify_minSlot :
     apply (smt ReduceStepResult.inject State.ext_inject State.surjective State.update_convs(3) State.update_convs(4) reduceContractStep.simps(5))
     by simp
 
-lemma timedOutReduceContractLoop_closes_contract : "minSlot sta \<le> iniSlot \<Longrightarrow>
-    maxTimeContract cont \<le> iniSlot \<Longrightarrow>
-    iniSlot \<le> endSlot \<Longrightarrow>
-    minSlot sta = iniSlot \<Longrightarrow>
-    reductionLoop reduced \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> sta cont x y =
+lemma timedOutReduceContractLoop_closes_contract : "minTime sta \<le> iniTime \<Longrightarrow>
+    maxTimeContract cont \<le> iniTime \<Longrightarrow>
+    iniTime \<le> endTime \<Longrightarrow>
+    minTime sta = iniTime \<Longrightarrow>
+    reductionLoop reduced \<lparr>timeInterval = (iniTime, endTime)\<rparr> sta cont x y =
     ContractQuiescent newReduced warning effect newState ncontract \<Longrightarrow>
     ncontract = Close"
-  apply (induction reduced "\<lparr>slotInterval = (iniSlot, endSlot)\<rparr>" sta cont x y arbitrary: warning effect newState ncontract rule:reductionLoop.induct)
+  apply (induction reduced "\<lparr>timeInterval = (iniTime, endTime)\<rparr>" sta cont x y arbitrary: warning effect newState ncontract rule:reductionLoop.induct)
   subgoal for reduced state contract warnings payments warning effect newState ncontract
-    apply (simp only:reductionLoop.simps[of reduced "\<lparr>slotInterval = (iniSlot, endSlot)\<rparr>" "(sta\<lparr>minSlot := iniSlot\<rparr>)" contract warnings payments])
-    apply (cases "reduceContractStep \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> state contract")
+    apply (simp only:reductionLoop.simps[of reduced "\<lparr>timeInterval = (iniTime, endTime)\<rparr>" "(sta\<lparr>minTime := iniTime\<rparr>)" contract warnings payments])
+    apply (cases "reduceContractStep \<lparr>timeInterval = (iniTime, endTime)\<rparr> state contract")
     subgoal for x11 x12 x13 x14
       apply (simp only:ReduceStepResult.case Let_def)
       subgoal premises facts
@@ -190,7 +190,7 @@ lemma timedOutReduceContractLoop_closes_contract : "minSlot sta \<le> iniSlot \<
         apply simp
         using facts(3) facts(7) maxTimeOnlyDecreases_reduceStep apply fastforce
         apply simp
-        using facts(5) facts(7) timedOutReduceStep_does_not_modify_minSlot apply blast
+        using facts(5) facts(7) timedOutReduceStep_does_not_modify_minTime apply blast
         by (metis (no_types, lifting) ReduceStepResult.simps(8) facts(6) facts(7) reductionLoop.simps)
       done
     using timedOutReduce_only_quiescent_in_close apply fastforce
@@ -198,33 +198,33 @@ lemma timedOutReduceContractLoop_closes_contract : "minSlot sta \<le> iniSlot \<
   done
 
 lemma timedOutReduceContractUntilQuiescent_closes_contract :
-  "iniSlot \<ge> minSlot sta
-   \<Longrightarrow> iniSlot \<ge> maxTimeContract cont
-   \<Longrightarrow> endSlot \<ge> iniSlot
-   \<Longrightarrow> reduceContractUntilQuiescent \<lparr>slotInterval = (max iniSlot (minSlot sta), endSlot)\<rparr> (sta\<lparr>minSlot := max iniSlot (minSlot sta)\<rparr>) cont
+  "iniTime \<ge> minTime sta
+   \<Longrightarrow> iniTime \<ge> maxTimeContract cont
+   \<Longrightarrow> endTime \<ge> iniTime
+   \<Longrightarrow> reduceContractUntilQuiescent \<lparr>timeInterval = (max iniTime (minTime sta), endTime)\<rparr> (sta\<lparr>minTime := max iniTime (minTime sta)\<rparr>) cont
    = ContractQuiescent reduced warning effect newState ncontract \<Longrightarrow> ncontract = Close"
   apply (simp only:reduceContractUntilQuiescent.simps)
   by (smt State.select_convs(4) State.surjective State.update_convs(4) timedOutReduceContractLoop_closes_contract)
 
 lemma timedOutReduceContractStep_empties_accounts :
   "validAndPositive_state sta \<Longrightarrow>
-    minSlot sta \<le> iniSlot \<Longrightarrow>
-    maxTimeContract cont \<le> iniSlot \<Longrightarrow>
-    iniSlot \<le> endSlot \<Longrightarrow>
-    reduceContractUntilQuiescent \<lparr>slotInterval = (iniSlot, endSlot)\<rparr> (sta\<lparr>minSlot := iniSlot\<rparr>) cont
+    minTime sta \<le> iniTime \<Longrightarrow>
+    maxTimeContract cont \<le> iniTime \<Longrightarrow>
+    iniTime \<le> endTime \<Longrightarrow>
+    reduceContractUntilQuiescent \<lparr>timeInterval = (iniTime, endTime)\<rparr> (sta\<lparr>minTime := iniTime\<rparr>) cont
      = ContractQuiescent reduced warning effect newState ncontract \<Longrightarrow> accounts newState = []"
   by (smt State.ext_inject State.surjective State.update_convs(4) allAccountsPositiveState.elims(3) isQuiescent.simps(1) positiveMoneyInAccountOrNoAccountImpliesAllAccountsPositive reduceContractUntilQuiecentIsQuiescent reduceContractUntilQuiescent.simps timedOutReduceContractLoop_closes_contract validAndPositiveImpliesPositive validAndPositiveImpliesValid validAndPositive_state.elims(3) valid_state.simps)
 
 theorem timedOutTransaction_closes_contract :
   "validAndPositive_state sta
-   \<Longrightarrow> iniSlot \<ge> minSlot sta
-   \<Longrightarrow> iniSlot \<ge> maxTimeContract cont
-   \<Longrightarrow> endSlot \<ge> iniSlot
+   \<Longrightarrow> iniTime \<ge> minTime sta
+   \<Longrightarrow> iniTime \<ge> maxTimeContract cont
+   \<Longrightarrow> endTime \<ge> iniTime
    \<Longrightarrow> accounts sta \<noteq> [] \<or> cont \<noteq> Close
-   \<Longrightarrow> isClosedAndEmpty (computeTransaction \<lparr> interval = (iniSlot, endSlot)
+   \<Longrightarrow> isClosedAndEmpty (computeTransaction \<lparr> interval = (iniTime, endTime)
                                             , inputs = [] \<rparr> sta cont)"
   apply (simp del:validAndPositive_state.simps reduceContractUntilQuiescent.simps add:Let_def)
-  apply (cases "reduceContractUntilQuiescent \<lparr>slotInterval = (max iniSlot (minSlot sta), endSlot)\<rparr> (sta\<lparr>minSlot := max iniSlot (minSlot sta)\<rparr>) cont")
+  apply (cases "reduceContractUntilQuiescent \<lparr>timeInterval = (max iniTime (minTime sta), endTime)\<rparr> (sta\<lparr>minTime := max iniTime (minTime sta)\<rparr>) cont")
   apply (simp only:ReduceResult.case list.case ApplyAllResult.case max_of_ge)
   apply (cases "cont = Close")
   apply (simp del:validAndPositive_state.simps reduceContractUntilQuiescent.simps)

--- a/isabelle/Core/TransactionBound.thy
+++ b/isabelle/Core/TransactionBound.thy
@@ -218,8 +218,8 @@ lemma applyAllLoop_decreases_maxTransactions :
     by simp
   done
 
-lemma minSlot_doesnt_affect_maxTransactions :
-  "maxTransactions cont (sta\<lparr>minSlot := y\<rparr>) = maxTransactions cont sta"
+lemma minTime_doesnt_affect_maxTransactions :
+  "maxTransactions cont (sta\<lparr>minTime := y\<rparr>) = maxTransactions cont sta"
   apply (cases cont)
   by simp_all
 
@@ -231,10 +231,10 @@ lemma fixInterval_preserves_maxTransactions :
   subgoal for left right
     apply (cases "right < left")
     apply simp
-    apply (cases "right < minSlot sta")
+    apply (cases "right < minTime sta")
     apply simp
     apply (simp del:maxTransactions.simps add:Let_def)
-    using minSlot_doesnt_affect_maxTransactions by blast
+    using minTime_doesnt_affect_maxTransactions by blast
   done
 
 lemma computeTransaction_decreases_maxTransactions_aux :

--- a/isabelle/Core/ValidState.thy
+++ b/isabelle/Core/ValidState.thy
@@ -25,8 +25,8 @@ lemma refundOne_preserves_valid_map_accounts :
 lemma reductionStep_preserves_valid_state_Refund :
   "valid_state state \<Longrightarrow>
    reduceContractStep env state Close = Reduced wa ef newState newCont \<Longrightarrow>
-   state = \<lparr>accounts = oldAccounts, choices = oldChoices, boundValues = oldBoundValues, minSlot = oldMinSlot\<rparr> \<Longrightarrow>
-   newState = \<lparr>accounts = newAccounts, choices = newChoices, boundValues = newBoundValues, minSlot = newMinSlot\<rparr> \<Longrightarrow>
+   state = \<lparr>accounts = oldAccounts, choices = oldChoices, boundValues = oldBoundValues, minTime = oldMinTime\<rparr> \<Longrightarrow>
+   newState = \<lparr>accounts = newAccounts, choices = newChoices, boundValues = newBoundValues, minTime = newMinTime\<rparr> \<Longrightarrow>
    valid_state newState"
   apply (cases "refundOne oldAccounts")
   using refundOne_preserves_valid_map_accounts by auto
@@ -152,7 +152,7 @@ lemma fixInterval_preserves_valid_state :
   apply (simp only:fixInterval.simps)
   apply (cases "b < a")
   apply simp
-  apply (cases "b < minSlot state")
+  apply (cases "b < minTime state")
   apply simp
   apply (simp del:valid_state.simps add:Let_def)
   by auto

--- a/isabelle/Doc/Specification/Core.thy
+++ b/isabelle/Doc/Specification/Core.thy
@@ -28,12 +28,12 @@ So to show records we need to duplicate the definition
 record State = accounts :: Accounts
                choices :: "(ChoiceId \<times> ChosenNum) list"
                boundValues :: "(ValueId \<times> int) list"
-               minSlot :: Slot
+               minTime :: POSIXTime
 
 subsection \<open>Environment\label{sec:environment}\<close>
 
 
-record Environment = slotInterval :: SlotInterval
+record Environment = timeInterval :: TimeInterval
 
 section \<open>Semantics\<close>
 
@@ -110,13 +110,13 @@ text \<open>@{thm evalValue_ChoiceValue}\<close>
 subsubsection \<open>Time Interval Start\<close>
 text \<open>All transactions are executed in the context of a valid time interval. For the \<^emph>\<open>TimeIntervalStart\<close> case,
 @{const evalValue} will return the beginning of that interval.\<close>
-text \<open>@{thm evalValue_SlotIntervalStart}\<close>
+text \<open>@{thm evalValue_TimeIntervalStart}\<close>
 
 
 subsubsection \<open>Time Interval End\<close>
 text \<open>All transactions are executed in the context of a valid time interval. For the \<^emph>\<open>TimeIntervalEnd\<close> case,
 @{const evalValue} will return the end of that interval.\<close>
-text \<open>@{thm evalValue_SlotIntervalEnd}\<close>
+text \<open>@{thm evalValue_TimeIntervalEnd}\<close>
 
 
 subsubsection \<open>Use Value\<close>

--- a/src/Language/Marlowe/Examples/Auction.hs
+++ b/src/Language/Marlowe/Examples/Auction.hs
@@ -7,7 +7,7 @@ import           Data.String      (IsString (..) )
 import           Language.Marlowe
 main :: IO ()
 main = print . pretty $ contract "Alice" 100 1000 ["Bob", "Charlie", "Dora"] 10
-contract :: Party -> Integer -> Integer -> [String] -> Slot -> Contract
+contract :: Party -> Integer -> Integer -> [String] -> POSIXTime -> Contract
 contract owner minBid maxBid bidders deadline = go Nothing [] $ map fromString bidders
   where
     go :: Maybe (Value, Party) -> [Party] -> [Party] -> Contract

--- a/src/Language/Marlowe/Examples/Escrow.hs
+++ b/src/Language/Marlowe/Examples/Escrow.hs
@@ -32,14 +32,14 @@ contract = When [Case (Deposit aliceAcc aliceRole ada price)
 -- Continues as specified when N out of M have agreed on a choice,
 -- continue as defCont if N can no longer agree, or on timeout
 
-whenNOutOfMChoose :: [(ChosenNum, Contract)] -> Integer -> [Party] -> Slot -> Contract
+whenNOutOfMChoose :: [(ChosenNum, Contract)] -> Integer -> [Party] -> POSIXTime -> Contract
                   -> Contract
 whenNOutOfMChoose ops n m timeout defCont =
   whenNOutOfMChooseAux eops n m timeout defCont
   where eops = [(0, ch, co) | (ch, co) <- ops]
 
 whenNOutOfMChooseAux :: [(Integer, ChosenNum, Contract)] -> Integer ->
-                        [Party] -> Slot -> Contract
+                        [Party] -> POSIXTime -> Contract
                      -> Contract
 whenNOutOfMChooseAux [] _ _ _ defCont = defCont
 whenNOutOfMChooseAux ops n partiesLeft timeout defCont

--- a/src/Language/Marlowe/Examples/Rent.hs
+++ b/src/Language/Marlowe/Examples/Rent.hs
@@ -4,7 +4,7 @@ module Language.Marlowe.Examples.Rent where
 import Language.Marlowe
 
 utilityMonths :: Integer -> Contract
-utilityMonths n = foldl (.) mkDeposit [payMonth (Slot x) | x <- [1..n]] Close
+utilityMonths n = foldl (.) mkDeposit [payMonth (POSIXTime x) | x <- [1..n]] Close
 
 utility :: Contract
 utility = mkDeposit $ payMonth 1 $ payMonth 2 $ payMonth 3 $ Close

--- a/src/Language/Marlowe/FindInputs.hs
+++ b/src/Language/Marlowe/FindInputs.hs
@@ -1,6 +1,6 @@
 module Language.Marlowe.FindInputs(getAllInputs) where
 
-import Language.Marlowe.Semantics.Types (Contract(..), Case(..), Observation(..), Slot)
+import Language.Marlowe.Semantics.Types (Contract(..), Case(..), Observation(..), POSIXTime)
 import Language.Marlowe.Analysis.FSSemanticsFastVerbose (warningsTrace)
 import Language.Marlowe.Semantics (TransactionInput)
 import Data.SBV (ThmResult)
@@ -42,7 +42,7 @@ expandContract (When cas sl con) = [When cas sl c | c <- expandContract con]
 expandContract (Let vi va con) = [Let vi va c | c <- expandContract con]
 expandContract (Assert _ con) = expandContract con
 
-getInputs :: Contract -> IO (Either (ThmResult, Contract) (Maybe (Slot, [TransactionInput])))
+getInputs :: Contract -> IO (Either (ThmResult, Contract) (Maybe (POSIXTime, [TransactionInput])))
 getInputs c = bimap (\tr -> (tr, c)) (fmap (\(s, t, _) -> (s, t))) <$> warningsTrace c
 
 -- | Uses static analysis to obtain a list of "unit tests" (lists of transactions) that
@@ -51,35 +51,35 @@ getInputs c = bimap (\tr -> (tr, c)) (fmap (\(s, t, _) -> (s, t))) <$> warningsT
 -- | extension of the contract
 -- >>> import Language.Marlowe.Examples.EscrowSimple
 -- >>> getAllInputs contract
--- Right [ (0, [ TransactionInput {txInterval = SlotInterval 10 10, txInputs = []}
+-- Right [ (0, [ TransactionInput {txInterval = TimeInterval 10 10, txInputs = []}
 --             ])
---       , (0, [ TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
---             , TransactionInput {txInterval = SlotInterval 90 90, txInputs = []}
+--       , (0, [ TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
+--             , TransactionInput {txInterval = TimeInterval 90 90, txInputs = []}
 --             ])
---       , (0, [ TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "bob")) 0)]}
---             , TransactionInput {txInterval = SlotInterval 100 100, txInputs = []}
+--       , (0, [ TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "bob")) 0)]}
+--             , TransactionInput {txInterval = TimeInterval 100 100, txInputs = []}
 --             ])
---       , (0, [ TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "bob")) 0)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "agree" (Role "carol")) 0)]}
+--       , (0, [ TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "bob")) 0)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "agree" (Role "carol")) 0)]}
 --             ])
---       , (0, [ TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "bob")) 0)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "agree" (Role "carol")) 1)]}
+--       , (0, [ TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "bob")) 0)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "agree" (Role "carol")) 1)]}
 --             ])
---       , (0, [ TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "alice")) 0)]}
---             , TransactionInput {txInterval = SlotInterval 100 100, txInputs = []}
+--       , (0, [ TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "alice")) 0)]}
+--             , TransactionInput {txInterval = TimeInterval 100 100, txInputs = []}
 --             ])
---       , (0, [ TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "alice")) 0)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "agree" (Role "carol")) 0)]}
+--       , (0, [ TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "alice")) 0)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "agree" (Role "carol")) 0)]}
 --             ])
---       , (0, [ TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "alice")) 0)]}
---             , TransactionInput {txInterval = SlotInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "agree" (Role "carol")) 1)]}
+--       , (0, [ TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IDeposit (Role "alice") (Role "alice") (Token "" "") 450)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "claim" (Role "alice")) 0)]}
+--             , TransactionInput {txInterval = TimeInterval 0 0, txInputs = [NormalInput (IChoice (ChoiceId "agree" (Role "carol")) 1)]}
 --             ])
 --       ]
-getAllInputs :: Contract -> IO (Either (ThmResult, Contract) [(Slot, [TransactionInput])])
+getAllInputs :: Contract -> IO (Either (ThmResult, Contract) [(POSIXTime,[TransactionInput])])
 getAllInputs c = second catMaybes . sequence <$> mapM getInputs (expandContract (removeAsserts c))

--- a/src/Language/Marlowe/Semantics/Deserialisation.hs
+++ b/src/Language/Marlowe/Semantics/Deserialisation.hs
@@ -2,8 +2,8 @@ module Language.Marlowe.Semantics.Deserialisation (byteStringToContract) where
 
 import Data.ByteString (ByteString)
 import Data.Ratio ((%))
-import Language.Marlowe.Semantics.Types (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Slot(Slot), Token(..),
-                                         Value(AddValue, AvailableMoney, ChoiceValue, Cond, Constant, DivValue, MulValue, NegValue, SlotIntervalEnd, SlotIntervalStart, SubValue, UseValue),
+import Language.Marlowe.Semantics.Types (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), POSIXTime(POSIXTime), Token(..),
+                                         Value(AddValue, AvailableMoney, ChoiceValue, Cond, Constant, DivValue, MulValue, NegValue, TimeIntervalEnd, TimeIntervalStart, SubValue, UseValue),
                                          ValueId(..),)
 import Language.Marlowe.Deserialisation (byteStringToInt, byteStringToList, byteStringToPositiveInt, getByteString)
 import Data.Text.Encoding (decodeUtf8)
@@ -203,13 +203,13 @@ byteStringToValue x =
                             Nothing -> Nothing
                             Just (choId, t2) -> Just (ChoiceValue choId, t2)
                         )
-                      else Just (SlotIntervalStart, t1)
+                      else Just (TimeIntervalStart, t1)
                   )
                 else
                   ( if y < 11
                       then
                         ( if y < 10
-                            then Just (SlotIntervalEnd, t1)
+                            then Just (TimeIntervalEnd, t1)
                             else
                               ( case byteStringToValueId t1 of
                                   Nothing -> Nothing
@@ -423,7 +423,7 @@ byteStringToContract x =
                                     ( case byteStringToContract t3 of
                                         Nothing -> Nothing
                                         Just (cont, t4) ->
-                                          Just (When caseList (Slot timeout) cont, t4)
+                                          Just (When caseList (POSIXTime timeout) cont, t4)
                                     )
                               )
                         )

--- a/src/Language/Marlowe/Semantics/Serialisation.hs
+++ b/src/Language/Marlowe/Semantics/Serialisation.hs
@@ -4,7 +4,7 @@ import           Data.Ratio (denominator, numerator)
 import qualified Data.Text.Encoding as Text
 import           Language.Marlowe.ExtendedBuilder (ExtendedBuilder)
 import qualified Language.Marlowe.ExtendedBuilder as ExtendedBuilder
-import           Language.Marlowe.Semantics.Types (Action (..), Bound (Bound), Case (..), ChoiceId (..), Contract (..), Observation (..), Party (..), Payee (..), Slot (Slot), Token (..), Value (..), ValueId (..))
+import           Language.Marlowe.Semantics.Types (Action (..), Bound (Bound), Case (..), ChoiceId (..), Contract (..), Observation (..), Party (..), Payee (..), POSIXTime (POSIXTime), Token (..), Value (..), ValueId (..))
 import           Language.Marlowe.Serialisation (intToByteString, listToByteString, packByteString, positiveIntToByteString)
 
 partyToByteString :: Party -> ExtendedBuilder
@@ -43,8 +43,8 @@ valueToByteString (SubValue lhs rhs) = positiveIntToByteString 4 <> valueToByteS
 valueToByteString (MulValue lhs rhs) = positiveIntToByteString 5 <> valueToByteString lhs <> valueToByteString rhs
 valueToByteString (DivValue lhs rhs) = positiveIntToByteString 6 <> valueToByteString lhs <> valueToByteString rhs
 valueToByteString (ChoiceValue choId) = positiveIntToByteString 7 <> choiceIdToByteString choId
-valueToByteString SlotIntervalStart = positiveIntToByteString 8
-valueToByteString SlotIntervalEnd = positiveIntToByteString 9
+valueToByteString TimeIntervalStart = positiveIntToByteString 8
+valueToByteString TimeIntervalEnd = positiveIntToByteString 9
 valueToByteString (UseValue valId) = positiveIntToByteString 10 <> valueIdToByteString valId
 valueToByteString (Cond cond thn els) = positiveIntToByteString 11 <> observationToByteString cond <> valueToByteString thn <> valueToByteString els
 
@@ -68,6 +68,6 @@ contractToByteString :: Contract -> ExtendedBuilder
 contractToByteString Close = positiveIntToByteString 0
 contractToByteString (Pay accId payee token val cont) = positiveIntToByteString 1 <> partyToByteString accId <> payeeToByteString payee <> tokenToByteString token <> valueToByteString val <> contractToByteString cont
 contractToByteString (If obs cont1 cont2) = positiveIntToByteString 2 <> observationToByteString obs <> contractToByteString cont1 <> contractToByteString cont2
-contractToByteString (When caseList (Slot timeout) cont) = positiveIntToByteString 3 <> listToByteString caseToByteString caseList <> intToByteString timeout <> contractToByteString cont
+contractToByteString (When caseList (POSIXTime timeout) cont) = positiveIntToByteString 3 <> listToByteString caseToByteString caseList <> intToByteString timeout <> contractToByteString cont
 contractToByteString (Let valId val cont) = positiveIntToByteString 4 <> valueIdToByteString valId <> valueToByteString val <> contractToByteString cont
 contractToByteString (Assert obs cont) = positiveIntToByteString 5 <> observationToByteString obs <> contractToByteString cont

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -21,7 +21,7 @@ import           Language.Marlowe.ACTUS.ActusContracts
 main :: IO ()
 main = do
     print $ contractLifespanUpperBound $
-        zeroCouponBondGuaranteed "investor" "issuer" "guarantor" 1000 200 (Slot 10) (Slot 20)
+        zeroCouponBondGuaranteed "investor" "issuer" "guarantor" 1000 200 (POSIXTime 10) (POSIXTime 20)
     now <- getCurrentTime
     let td = utctDay now
     let couponBondFor3Month12PercentConfig = cb td (addGregorianMonthsClip 3 td) 1000 0.12
@@ -50,13 +50,13 @@ couponBondFor3Month12Percent =
                             -- expects to receive notional + interest payment
                             (When [ Case (Deposit "investor" "issuer" ada (Constant 1010))
                                 (Pay "investor" (Party "investor") ada (Constant 1010) Close)]
-                            (Slot 1571788789)
+                            (POSIXTime 1571788789)
                             Close))]
-                    (Slot 1569196789)
+                    (POSIXTime 1569196789)
                     Close))]
-            (Slot 1566518389)
+            (POSIXTime 1566518389)
             Close))]
-    (Slot 1563839989)
+    (POSIXTime 1563839989)
     Close
 
 
@@ -67,12 +67,12 @@ zeroCouponBond = When [ Case
                 [ Case (Deposit "investor" "issuer" ada (Constant 1000))
                         (Pay "investor" (Party "investor") ada (Constant 1000) Close)
                 ]
-                (Slot 1579305589)
+                (POSIXTime 1579305589)
                 Close
             )
         )
     ]
-    (Slot 1563407989)
+    (POSIXTime 1563407989)
     Close
 
 couponBondGuaranteed = When [Case (Deposit "investor" "guarantor" ada (Constant 1030))
@@ -87,11 +87,11 @@ couponBondGuaranteed = When [Case (Deposit "investor" "guarantor" ada (Constant 
                             (When [Case (Deposit "investor" "issuer" ada (Constant 1010))
                                 (Pay "investor" (Party "investor") ada (Constant 1010)
                                 (Pay "investor" (Party "guarantor") ada (Constant 1010) Close))]
-                            (Slot 1571788789) Close)))]
-                    (Slot 1569196789) Close)))]
-            (Slot 1566518389) Close))]
-    (Slot 1563839989) Close)]
-    (Slot 1563839989) Close
+                            (POSIXTime 1571788789) Close)))]
+                    (POSIXTime 1569196789) Close)))]
+            (POSIXTime 1566518389) Close))]
+    (POSIXTime 1563839989) Close)]
+    (POSIXTime 1563839989) Close
 
 
 couponBondGuaranteedWithAccounts =
@@ -106,20 +106,20 @@ couponBondGuaranteedWithAccounts =
                             (Pay "party1" (Party "party1") ada (Constant 10)
                                 (When [Case (Deposit "party1" "party2" ada (Constant 1010))
                                     (Pay "party1" (Party "party1") ada (Constant 1010) Close)]
-                                (Slot 1571788789)
+                                (POSIXTime 1571788789)
                                 -- if the issues fails to return notional
                                 -- guarantor pays from his account and refunds
                                 (Pay "party2" (Party "party1") ada (Constant 1010) Close))
                             )]
-                        (Slot 1569196789)
+                        (POSIXTime 1569196789)
                         -- guarantor pays from his account and refunds
                         (Pay "party2" (Party "party1") ada (Constant 1020) Close)))]
-                (Slot 1566518389)
+                (POSIXTime 1566518389)
                 -- guarantor pays from his account and refunds
                 (Pay "party2" (Party "party1") ada (Constant 1030) Close)))]
         -- if partees do not proceed guarantor automatically gets his money back
-        (Slot 1563839989) Close)]
-    (Slot 1563839989) Close
+        (POSIXTime 1563839989) Close)]
+    (POSIXTime 1563839989) Close
 
 
 couponBondGuaranteedWithoutAccounts =
@@ -134,22 +134,22 @@ couponBondGuaranteedWithoutAccounts =
                             (Pay "party1" (Party "party1") ada (Constant 10)
                                 (When [Case (Deposit "party1" "party2" ada (Constant 1010))
                                     (Pay "party1" (Party "party1") ada (Constant 1010) Close)]
-                                (Slot 1571788789)
+                                (POSIXTime 1571788789)
                                 (Pay "party1" (Party "party1") ada (Constant 1010)
                                 -- with single account we have to
                                 -- manually redistibute money to guarantor
                                 (Pay "party1" (Party "guarantor") ada (Constant 20) Close))))]
-                        (Slot 1569196789)
+                        (POSIXTime 1569196789)
                         (Pay "party1" (Party "party1") ada (Constant 1020)
                         -- in all the cases
                         (Pay "party1" (Party "guarantor") ada (Constant 10) Close))))]
-                (Slot 1566518389)
+                (POSIXTime 1566518389)
                 -- here as well
                 (Pay "party1" (Party "party1") ada (Constant 1030) Close)))]
-        (Slot 1563839989)
+        (POSIXTime 1563839989)
         -- and thes are only 3 payments
         (Pay "party1" (Party "guarantor") ada (Constant 1030) Close))]
-    (Slot 1563839989) Close
+    (POSIXTime 1563839989) Close
 
 
 {- Simply swap two payments between parties -}
@@ -172,8 +172,8 @@ swapExample =
             Close)
         ] (date1 - gracePeriod) Close
   where
-    gracePeriod = Slot 3*60*24 -- 24 hours
-    date1 = Slot 1563839989
+    gracePeriod = POSIXTime 3*60*24 -- 24 hours
+    date1 = POSIXTime 1563839989
     acc1 = "party1"
     acc2 = "party2"
 
@@ -183,17 +183,17 @@ swapSingleAccount =
             (When [ Case (Deposit acc1 "party2" ada (Constant 300))
                 (Pay acc1 (Party "party2") ada (Constant 500)
                 (Pay acc1 (Party "party1") ada (Constant 300) Close))
-                ] (Slot date1)
+                ] (POSIXTime date1)
             -- refund to the 1st party
             (Pay acc1 (Party "party1") ada (Constant 500) Close))
          , Case (Deposit acc1 "party2" ada (Constant 300))
             (When [ Case (Deposit acc1 "party1" ada (Constant 500))
                 (Pay acc1 (Party "party2") ada (Constant 500)
                 (Pay acc1 (Party "party1") ada (Constant 300) Close))
-            ] (Slot date1)
+            ] (POSIXTime date1)
             -- refund to the 2nd party
             (Pay acc1 (Party "party2") ada (Constant 300) Close))
-        ] (Slot (date1 - gracePeriod)) Close
+        ] (POSIXTime (date1 - gracePeriod)) Close
   where
     gracePeriod = 3*60*24 -- 24 hours
     date1 = 1563839989
@@ -223,8 +223,8 @@ swapGuaranteedExample =
             Close)
         ] (date1 - 2 * gracePeriod) Close
   where
-    gracePeriod = Slot 3*60*24 -- 24 hours
-    date1 = Slot 1563839989
+    gracePeriod = POSIXTime 3*60*24 -- 24 hours
+    date1 = POSIXTime 1563839989
     acc1 = "party1"
     acc2 = "party2"
     acc3 = "guarantor"
@@ -262,8 +262,8 @@ swapSingleAccountGuaranteedExample =
             (Pay acc1 (Party "guarantor") ada (Constant 800) Close))
         ] (date1 - 2 * gracePeriod) Close
     where
-    gracePeriod = Slot 3*60*24 -- 24 hours
-    date1 = Slot 1563839989
+    gracePeriod = POSIXTime 3*60*24 -- 24 hours
+    date1 = POSIXTime 1563839989
     acc1 = "party1"
     acc2 = "party2"
     acc3 = "guarantor"

--- a/using-marlowe.md
+++ b/using-marlowe.md
@@ -23,11 +23,11 @@ processTransaction :: Transaction -> State -> Contract -> ProcessResult
 Where `Transaction` is defined as:
 
 ```haskell
-data Transaction = Transaction { interval :: SlotInterval
+data Transaction = Transaction { interval :: TimeInterval
                                , inputs :: [Input] }
 ```
 
-Where `interval` represents the slot interval in which the transaction is added to the blockchain. And `inputs` is a list
+Where `interval` represents the time interval in which the transaction is added to the blockchain. And `inputs` is a list
 of the actions issued by participants as part of the transaction.
 
 `ProcessResult` is defined as:
@@ -86,7 +86,7 @@ users, and the highest known lower bound for the most recent slot number.
 ```haskell
 data State = State { account :: Map AccountId Money
                    , choice :: Map ChoiceId ChosenNum
-                   , minSlot :: SlotNumber }
+                   , minTime :: POSIXTime }
 ```
 
 ## Inputs
@@ -133,7 +133,7 @@ at each stage, the contract continuation, i.e. what remains to be executed, and 
 > Explore some other ways of engaging with the contract
 > - What happens when the guarantor does not make the deposit on time?
 > - What happens when the issuer does not return the money?
-> - What happens when we pass an interval that includes slots both before and after a timeout?
+> - What happens when we pass an interval that includes times both before and after a timeout?
 
 ## There must be an easier way!
 

--- a/using-marlowe.md
+++ b/using-marlowe.md
@@ -66,7 +66,7 @@ To single step, you can work in `ghci` like this, using the facility to make loc
 ```
 
 Where `inps`s are lists of inputs that may include any number of inputs depending on the context, the numbers `li`s and
-`hi`s denote the interval in which the slot number in which each transaction is accepted in the blockchain.
+`hi`s denote the time interval in which each transaction is accepted in the blockchain.
 
 We can then explore the values produced. Note, however, that the local bindings are lost each time a `:load` or `:l` command
 is performed.
@@ -81,7 +81,7 @@ steps taken, and did not cover the constituent types in much detail. These are a
 ## State
 
 The `State` of a Marlowe contract keeps track of the amount of money in each `account`, the values of `choice`s made by
-users, and the highest known lower bound for the most recent slot number.
+users, and the highest known lower bound for time (the maximum of the lower bounds of the intervals and start time).
 
 ```haskell
 data State = State { account :: Map AccountId Money


### PR DESCRIPTION
This PR modifies code and documentation to use POSIXTime instead of slot numbers. Essentially just a renaming because internally it has always been integers. But also some rephrasing in the documentation