### PR TITLE
SCP-4320 SCP-4321 SCP-4322 Isabelle specifications for Core Marlowe

### DIFF
--- a/isabelle/Doc/Specification/Core.thy
+++ b/isabelle/Doc/Specification/Core.thy
@@ -17,6 +17,8 @@ execution environment for contracts.\<close>
 
 text \<open>FIXME: Figure out how to prevent erasure of type synonyms in the antiquotations in this
 section.\<close>
+text \<open>FIXME: Figure out how to display type synonyms where they are displayed in this section.\<close>
+text \<open>FIXME: Figure out how to emit Isabelle instead of Haskell in "code stmnts" construct.\<close>
 
 subsection \<open>Contract\<close>
 
@@ -27,6 +29,7 @@ one or more continuations for subsequent contract(s). The @{term When} and
 make an assertion about the contract's state that a particular condition should hold at that point
 in the contract.
 @{datatype [display,names_short, margin=40]Contract}
+\<close> text \<open>FIXME: print type synonym: @{term [names_short, margin=40]Timeout}
 \<close>
 
 text \<open>A contract @{term Close} provides for the contract to be closed (or terminated). The only
@@ -92,10 +95,10 @@ text \<open>A @{term "Deposit a p t v"} makes a deposit of value @{term v} of to
 text \<open>A choice @{term "Choice i bs"} is made for a particular choice identified by @{term i}  with a
 list of inclusive bounds @{term bs} on the values that are acceptable. For example,
 @{text "[Bound 0 0, Bound 3 5]"} offers the choice of one of 0, 3, 4 and 5.
-@{term [display,names_short, margin=40]Bound}
+\<close> text \<open>FIXME: print type synonym: @{term [names_short, margin=40]Bound}
 @{datatype [display,names_short, margin=40]ChoiceId}
-@{term [display,names_short, margin=40]ChoiceName}
-Choices of integers, @{term "ChoiceId c p"} are identified by the name @{term n} for the choice
+\<close> text \<open>FIXME: print type synonym: @{term [names_short, margin=40]ChoiceName}
+\<close> text \<open>Choices of integers, @{term "ChoiceId c p"} are identified by the name @{term n} for the choice
 and the party @{term p} who had made the choice.\<close>
 
 text \<open>The contract is notified that a particular observation @{term b} is made via
@@ -104,101 +107,239 @@ notification would be done by one of the parties, or one of their wallets acting
 Notifications also have the effect of pausing contract execution until the @{term Notify} is
 received.\<close>
 
+subsection \<open>Input\<close>
+
+text \<open>External @{type Input} to a contract directly corresponds to the @{type Action} that handles
+such input.
+@{datatype [display,names_short, margin=40]Input}
+\<close>
+
+text \<open>A deposit input @{term "IDeposit a p t v"} exactly matches the action
+@{term "Deposit a p t v"}. A choice input @{term "IChoice i x"} corresponds to the action
+@{term "Choice i bs"} where the integer @{term x} falls within the bounds @{term bs}. The input
+@{term INotify} triggers the contract to evaluate the condition @{term b} in the action
+@{term "Notify b"}.\<close>
+
 subsection \<open>Party and Payee\label{sec:party}\<close>
 
 text \<open>A payment can be made to one of the parties to the contract, or to one of the accounts of the
 contract. A party may be identified by a public-key hash or by a role.
 @{datatype [display,names_short, margin=40]Payee}
 @{datatype [display,names_short, margin=40]Party}
+\<close> text \<open>FIXME: print type synonym: @{term [names_short, margin=40]AccountId}
 \<close>
 
 text \<open>@{term "Account p"} identifies the internal account for party @{term p}, whereas
 @{term "Party p"} identifies the internal account for that party.\<close>
 
 text \<open>@{term "PubKey h"} identifies a party by the hash @{term h} of a public key, whereas
-@{term "Role n"} identifies the party by the name @{term n} of their role.\<close>
-
-text \<open>\<close>
-
+@{term "Role n"} identifies the party by the name @{term n} of their role.
+\<close> text \<open>FIXME: print type synonym: @{term [names_short, margin=40]PubKey}
+  \<close>
 
 subsection \<open>Value\label{sec:value}\<close>
-text \<open>@{datatype [display,names_short, margin=40]Value}\<close>
+
+text \<open>A @{type Value} is a term that evaluates to an integer, given the current state of the Marlowe
+contract.
+@{datatype [display,names_short, margin=40]Value}
+\<close>
+
+text \<open>Three of the @{type Value} terms look up information in the Marlowe state:
+@{term "AvailableMoney p t"} reports the amount of token @{term t} in the internal account of party
+@{term p}; @{term "ChoiceValue i"} reports the most recent value chosen for choice @{term i}, or
+zero if no such choice has been made; and @{term "UseValue i"} reports the most recent value of the
+variable @{term i}, or zero if that variable has not yet been set to a value.\<close>
+
+text \<open>@{term "Constant v"} evaluates to the integer @{term x}, while @{term "NegValue x"},
+@{term "AddValue x y"}, @{term "SubValue x y"}, @{term "MulValue x y"}, and @{term "DivValue x y"}
+provide the common arithmetic operations @{term "- x"}, @{term "x + y"}, @{term "x - y"},
+@{term "x * y"}, and @{term "x / y"}, where division always rounds (truncates) its result towards
+zero.\<close>
+
+text \<open>@{term "Cond b x y"} represents a condition expressions that evaluates to @{term x} if
+@{term b} is true and to @{term y} if @{term b} is false.\<close>
+
+text \<open>Finally, @{term TimeIntervalStart} and @{term TimeIntervalEnd} evaluate respectively to the
+start or end of the validity interval for the Marlowe transaction.\<close>
 
 subsection \<open>Observation\label{sec:observation}\<close>
-text \<open>@{datatype [display,names_short, margin=40]Observation}\<close>
 
-subsection \<open>Input\<close>
-text \<open>@{datatype [display,names_short, margin=40]Input}\<close>
+text \<open>A @{type Observation} evaluates to a logical value (true or false), given the current statet
+of the Marlowe contract.
+@{datatype [display,names_short, margin=40]Observation}
+\<close>
+
+text \<open>The @{term "ChoseSomething i"} term reports whether a choice @{term i} has been made thus far in
+the contract.\<close>
+
+text \<open>The terms @{term TrueObs} and @{term FalseObs} provide the logical constants @{value true} and
+@{value false}. The logical operators @{term "\<not> x"}, @{term "x \<and> y"},
+and @{term "x \<or> y"}are represented by the terms @{term "NotObs x"}, @{term "AndObs x y"}, and
+@{term "OrObs x y"}, respectively.\<close>
+
+text \<open>Value comparisons @{term "x < y"}, @{term "x \<le> y"}, @{term "x > y"}, @{term "x \<ge> y"},
+and @{term "x = y"} are represented by @{term "ValueLT x y"}, @{term "ValueLE x y"},
+@{term "ValueGT x y"}, @{term "ValueGE x y"}, and @{term "ValueEQ x y"}.\<close>
+
+subsection \<open>Token\label{sec:token}\<close>
+
+text \<open>Each currency in the contract is represented by a @{type Token} that consists of a symbol
+@{term CurrencySymbol} and a name @{term TokenName}, each represented by bytes.
+@{datatype [display,names_short, margin=40]Token}
+\<close> text \<open>FIXME: print type synonym: @{term [names_short, margin=40]CurrencySymbol}
+\<close> text \<open>FIXME: print type synonym: @{term [names_short, margin=40]TokenName}
+\<close>
 
 subsection \<open>State\label{sec:state}\<close>
-text \<open>FIXME: Figure out how to display records via antiquotation.\<close>
+
+text \<open>The internal state of a Marlowe contract consists of the current balances in each party's
+account, a record of the most recent value of each type of choice, a record of the most recent
+value of each variable, and the minimum time for which input can be applied to the contract. The
+data for accounts, choices, and bound values are stored as association lists.\<close>
 (* Sadly there is no antiquote to print a record, and I wasn't able to 
 make the snipet import work (described in chapter 7 of the Sugar Latex PDF).
 So to show records we need to duplicate the definition
  *)
+text \<open>FIXME: Print record:\<close>
 record State = accounts :: Accounts
                choices :: "(ChoiceId \<times> ChosenNum) list"
                boundValues :: "(ValueId \<times> int) list"
                minTime :: POSIXTime
+text \<open>FIXME: print type synonym: @{term [names_short, margin=40]Accounts}\<close>
 
 subsection \<open>Environment\label{sec:environment}\<close>
 
-text \<open>FIXME: Figure out how to display records via antiquotation.\<close>
+text \<open>The execution environment of a Marlowe contract simply consists of the (inclusive) time
+interval within which the transaction is occurring.\<close>
 record Environment = timeInterval :: TimeInterval
-
-
-subsection \<open>Token\label{sec:token}\<close>
-text \<open>@{datatype [display,names_short, margin=40]Token}\<close>
-
-subsection \<open>Type Synonyms\label{sec:synonyms}\<close>
-text \<open>FIXME: Figure out how to display type synonyms here.\<close>
-
+text \<open>FIXME: Print record:
+@{term [names_short, margin=40]TimeInterval}
+\<close>
 
 section \<open>Semantics\<close>
 
-text \<open>TODO: Add the different functions and explanation \<close>
+text \<open>Marlowe's behavior is defined via the \<^emph>\<open>operational semantics\<close> (or \<^emph>\<open>executable
+semantics\<close>) of the Isabelle implementation of its @{const computeTransaction} function. That
+function calls several auxiliary functions to apply inputs and find a quiescent state of the
+contract. These, in turn, call evaluators for @{term Value} and @{term Observation}.\<close>
 
+subsection \<open>Compute Transaction\label{sec:computeTransaction}\<close>
 
+text \<open>The entry point into Marlowe semantics is the function @{const computeTransaction} that
+applies input to a prior state to transition to a posterior state, perhaps reporting warnings or
+throwing an error, all in the context of an environment for the transaction.\<close>
+text \<open>@{const computeTransaction} :: @{typeof computeTransaction}\<close>
+text \<open>FIXME: Print record: @{term [names_short, margin=40]Transaction}
+@{datatype [display,names_short, margin=40]TransactionOutput}
+\<close> text \<open>FIXME: Print record: @{term [names_short, margin=40]TransactionOutputRecord}
+\<close>
 
-subsection \<open>Eval value\<close>
-text \<open>Given the \hyperref[sec:environment]{@{typ Environment}} and the current 
+text \<open>This function adjusts the time interval for the transaction using @{const fixInterval} and
+then applies all of the transaction inputs to the contract using @{const applyAllInputs}. It
+reports relevant warnings and throws relevant errors.\<close>
+text \<open>@{code_stmts computeTransaction constant: computeTransaction (Haskell)}\<close>
+
+subsection \<open>Fix Interval\<close>
+
+text \<open>The @{const fixInterval} functions combines the minimum-time constraint of @{term State}
+with the time interval of @{term Environment} to yield a "trimmed" validity interval and a minimum
+time for the new state that will result from applying the transaction. It throws an error if the
+interval is nonsensical or in the past.\<close>
+text \<open>@{code_stmts fixInterval constant: fixInterval (Haskell)}\<close>
+
+subsection \<open>Apply All Inputs\label{sec:applyAllInputs}\<close>
+
+text \<open>The @{const applyAllInputs} function iteratively applies the transaction inputs to the state,
+checking for errors along the way and continuing until the contract reaches a quiescent state.\<close>
+text \<open>@{code_stmts applyAllInputs constant: applyAllInputs (Haskell)}\<close>
+text \<open>@{code_stmts applyAllLoop constant: applyAllLoop (Haskell)}\<close>
+
+subsection \<open>Reduce Contract Until Quiescent\label{sec:reduceContractUntilQuiescent}\<close>
+
+text \<open>The @{const reduceContractUntilQuiescent} executes as many non-input steps of the contract as
+is possible.\<close>
+text \<open>@{code_stmts reduceContractUntilQuiescent constant: reduceContractUntilQuiescent (Haskell)}\<close>
+
+subsection \<open>Reduction Loop\label{sec:reductionloop}\<close>
+
+text \<open>The @{const reductionLoop} function attempts to apply the next, non-input step to the
+contract. It emits warnings along the way and it will through an error if it encounters an
+ambiguous time interval.\<close>
+text \<open>@{code_stmts reductionLoop constant: reductionLoop (Haskell)}\<close>
+
+subsection \<open>Reduce Contract Step\label{sec:reducecontractstep}\<close>
+
+text \<open>The @{const reduceContractStep} function handles is @{type Contract} case, performing the
+relevant action (payments, state-change, etc.), reporting warning and throwing errors if needed.\<close>
+text \<open>@{code_stmts reduceContractStep constant: reduceContractStep (Haskell)}\<close>
+
+subsection \<open>Apply Input\label{sec:applyinput}\<close>
+
+text \<open>The @{const applyInput} function attempts to apply the next input each @{term Case} in the
+@{term When}, in sequence.\<close>
+text \<open>@{code_stmts applyInput constant: applyInput (Haskell)}\<close>
+
+subsection \<open>Apply Cases\label{sec:applycases}\<close>
+
+text \<open>The @{const applyCases} function attempts to match an @{term Input} to an @{term Action},
+compute the new contract state, emit warnings, throw errors if needed, and determine the appropriate
+continuation of the contract.\<close>
+text \<open>@{code_stmts applyCases constant: applyCases (Haskell)}\<close>
+
+subsection \<open>Account Utilitiesn\label{sec:accountutilities}\<close>
+
+text \<open>The @{const moneyInAccount}, @{const updateMoneyInAccount}, and @{const addMoneyToAccount}
+functions read, write, and increment the funds in a particular account of the @{term State},
+respectively. The @{const giveMoney} function transfer funds internally between accounts. The
+@{const refundOne} function finds the first account with funds in it.\<close>
+text \<open>@{code_stmts moneyInAccount constant: moneyInAccount (Haskell)}\<close>
+text \<open>@{code_stmts updateMoneyInAccount constant: updateMoneyInAccount (Haskell)}\<close>
+text \<open>@{code_stmts addMoneyToAccount constant: addMoneyToAccount (Haskell)}\<close>
+text \<open>@{code_stmts giveMoney constant: giveMoney (Haskell)}\<close>
+text \<open>@{code_stmts refundOne constant: refundOne (Haskell)}\<close>
+
+subsection \<open>Evaluate Value\label{sec:evalvalue}\<close>
+
+text \<open>Given the \hyperref[sec:environment]{@{typ Environment}} and the current
  \hyperref[sec:state]{@{typ State}}, the @{const evalValue} function 
 evaluates a \hyperref[sec:value]{@{typ Value}} into a number\<close>
 
-text \<open>\<^emph>\<open>evalValue\<close> :: @{typeof evalValue}\<close>
+text \<open>@{const evalValue} :: @{typeof evalValue}\<close>
 
-subsubsection \<open>Available money\<close>
+subsubsection \<open>Available Money\<close>
+
 text \<open>For the \<^emph>\<open>AvailableMoney\<close> case, @{const evalValue} will give us the amount of @{typ Token}s
 that a @{typ Party} has in their internal account.\<close>
 
 text \<open>@{thm evalValue_AvailableMoney}\<close>
 
 subsubsection \<open>Constant\<close>
+
 text \<open>For the \<^emph>\<open>Constant\<close> case, @{const evalValue} will always evaluate to the same value\<close>
 
 text \<open>@{thm evalValue_Constant}\<close>
 
-subsubsection \<open>Add value\<close>
+subsubsection \<open>Addition\<close>
 
 text \<open>For the \<^emph>\<open>AddValue\<close> case, @{const evalValue} will evaluate both sides and add them together.\<close>
 
 text \<open>@{thm evalValue_AddValue}\<close>
 
-text \<open>addition is associative\<close>
+text \<open>Addition is associative and commutative:\<close>
 
 text \<open>@{thm evalAddAssoc}\<close>
 
-text \<open>and commutative \<close>
-
 text \<open>@{thm evalAddCommutative}\<close>
 
-subsubsection \<open>Substract value\<close>
-text \<open>For the \<^emph>\<open>SubValue\<close> case, @{const evalValue} will evaluate both sides and substract
+subsubsection \<open>Subtraction\<close>
+
+text \<open>For the \<^emph>\<open>SubValue\<close> case, @{const evalValue} will evaluate both sides and subtract
 the second value to the first.\<close>
 
 text \<open>@{thm evalValue_SubValue}\<close>
 
-subsubsection \<open>Negative\<close>
+subsubsection \<open>Negation\<close>
+
 text \<open>For every value \<^emph>\<open>val\<close> there is the complement \<^emph>\<open>NegValue val\<close> so that\<close>
 
 text \<open>@{thm evalNegValue}\<close>
@@ -206,86 +347,122 @@ text \<open>@{thm evalNegValue}\<close>
 subsubsection \<open>Multiplication\<close>
 
 text \<open>For the \<^emph>\<open>MulValue\<close> case, @{const evalValue} will evaluate both sides and multiply them.\<close>
+
 text \<open>@{thm evalValue_MulValue}\<close>
 
 subsubsection \<open>Division\<close>
-text \<open>Division is a special case because we only evaluate to natural numbers:
+
+text \<open>Division is a special case because we only evaluate to natural numbers: 
 \<^item> If the numerator is 0, the denominator is not evaluated and the result is 0
 \<^item> If the denominator is 0, the result is also 0. Other languages uses NaN or Infinity to represent this case
-\<^item> The result will be rounded down if the remainder is lower than 1/2
-\<^item> The result will be rounded up if the remainder is bigger than 1/2
-\<^item> If the remainder is exactly 1/2, the result will be rounded down if the quotient is even or up if it is odd\<close>
+\<^item> The result will be rounded towards zero.\<close>
 
 text \<open>@{thm [display,names_short, margin=40] evalValue_DivValue}\<close>
+
 text \<open>TODO: lemmas around division? maybe extend the following to proof evalValue and not just div\<close>
 text \<open>@{thm divMultiply}\<close>
 text \<open>@{thm divAbsMultiply}\<close>
+text \<open>COMMENT(BWB): I suggest that the lemmas be (i) exact multiples divide with no remainder, (ii)
+      the remainder equals the excess above an exact multiple, and (iii) negation commutues with
+      division.\<close>
 
 subsubsection \<open>Choice Value\<close>
+
 text \<open>For the \<^emph>\<open>ChoiceValue\<close> case, @{const evalValue} will look in its state if a @{typ Party} has
 made a choice for the @{typ ChoiceName}. It will default to zero if it doesn't find it.\<close>
 text \<open>@{thm evalValue_ChoiceValue}\<close>
 
 subsubsection \<open>Time Interval Start\<close>
+
 text \<open>All transactions are executed in the context of a valid time interval. For the \<^emph>\<open>TimeIntervalStart\<close> case,
 @{const evalValue} will return the beginning of that interval.\<close>
 text \<open>@{thm evalValue_TimeIntervalStart}\<close>
 
-
 subsubsection \<open>Time Interval End\<close>
+
 text \<open>All transactions are executed in the context of a valid time interval. For the \<^emph>\<open>TimeIntervalEnd\<close> case,
 @{const evalValue} will return the end of that interval.\<close>
 text \<open>@{thm evalValue_TimeIntervalEnd}\<close>
 
-
 subsubsection \<open>Use Value\<close>
+
 text \<open>For the \<^emph>\<open>TimeIntervalEnd\<close> case, @{const evalValue} will look in its state for a bound @{typ ValueId}.
 It will default to zero if it doesn't find it.\<close>
 
 text \<open>@{thm evalValue_UseValue}\<close>
 
 subsubsection \<open>Conditional Value\<close>
-text \<open>For the \<^emph>\<open>Cond\<close> case, @{const evalValue} will first call \hyperref[sec:evalobservation]{@{const evalObservation}} 
+
+text \<open>For the \<^emph>\<open>Cond\<close> case, @{const evalValue} will first call \hyperref[sec:evalobservation]{@{const evalObservation}}
 on the condition, and it will evaluate the the true or false value depending on the result.\<close>
 
 text \<open>@{thm evalValue_Cond}\<close>
 
-subsection \<open>Eval Observation\label{sec:evalobservation}\<close>
-text \<open>TODO: explain\<close>
-text \<open>@{code_stmts evalObservation constant: evalObservation (Haskell)}\<close>
+subsection \<open>Evaluate Observation\label{sec:evalobservation}\<close>
 
-subsection \<open>Reduction Loop\label{sec:reductionloop}\<close>
+text \<open>Given the \hyperref[sec:environment]{@{typ Environment}} and the current
+ \hyperref[sec:state]{@{typ State}}, the @{const evalObservation} function 
+evaluates an \hyperref[sec:observation]{@{typ Observation}} into a number\<close>
 
-text \<open>TODO: explain\<close>
-text \<open>@{code_stmts reductionLoop constant: reductionLoop (Haskell)}\<close>
+text \<open>@{const evalObservation} :: @{typeof evalObservation}\<close>
 
-subsection \<open>Reduce Contract Until Quiescent\label{sec:reduceContractUntilQuiescent}\<close>
+subsubsection \<open>True and False\<close>
 
-text \<open>TODO: explain\<close>
-text \<open>@{code_stmts reduceContractUntilQuiescent constant: reduceContractUntilQuiescent (Haskell)}\<close>
+text \<open>The logical constants @{value true} and @{value false} are trivially evaluated.\<close>
 
-subsection \<open>Apply All Inputs\label{sec:applyAllInputs}\<close>
-text \<open>TODO: explain\<close>
-text \<open>@{code_stmts applyAllInputs constant: applyAllInputs (Haskell)}\<close>
+text \<open>@{thm evalObservation_TrueObs}\<close>
 
-subsection \<open>Compute Transaction\label{sec:computeTransaction}\<close>
-text \<open>TODO: explain\<close>
-text \<open>@{code_stmts computeTransaction constant: computeTransaction (Haskell)}\<close>
+text \<open>@{thm evalObservation_FalseObs}\<close>
+
+subsubsection \<open>Not, And, Or\<close>
+
+text \<open>The standard logical operators \<open>\<not>\<close>, \<open>\<and>\<close>, and \<open>\<or>\<close> are evaluated in a
+straightforward manner.\<close>
+
+text \<open>@{thm evalObservation_NotObs}\<close>
+
+text \<open>@{thm evalObservation_AndObs}\<close>
+
+text \<open>@{thm evalObservation_OrObs}\<close>
+
+subsubsection \<open>Comparison of Values\<close>
+
+text \<open>Five functions are provided for the comparison (equality and ordering of integer values) have
+traditional evaluations: \<open>=\<close>,\<open><\<close>, \<open>\<le>\<close>, \<open>>\<close>, and \<open>\<ge>\<close>.\<close>
+
+text \<open>@{thm evalObservation_ValueEQ}\<close>
+
+text \<open>@{thm evalObservation_ValueLT}\<close>
+
+text \<open>@{thm evalObservation_ValueLE}\<close>
+
+text \<open>@{thm evalObservation_ValueGT}\<close>
+
+text \<open>@{thm evalObservation_ValueGE}\<close>
+
+subsubsection \<open>Chose Something\<close>
+
+text \<open>The @{term "ChoseSometing i"} term evaluates to true if the a choice @{term i} was previously
+made in the history of the contract.\<close>
+
+text \<open>@{thm evalObservation_ChoseSomething}\<close>
+
+(*
 
 subsection \<open>Play Trace\label{sec:playTrace}\<close>
+
 text \<open>TODO: explain\<close>
 text \<open>@{code_stmts playTrace constant: playTrace (Haskell)}\<close>
 
 subsection \<open>Max Time\<close>
+
 text \<open>TODO: explain\<close>
 text \<open>@{code_stmts maxTimeContract constant: maxTimeContract (Haskell)}\<close>
 
-subsection \<open>Fix Interval\<close>
-text \<open>TODO: explain\<close>
-text \<open>@{code_stmts fixInterval constant: fixInterval (Haskell)}\<close>
-
 section \<open>Serialization\<close>
 text \<open>TODO: Json and Cbor serialization\<close>
+
+*)
 
 (*<*)
 end

--- a/isabelle/Doc/Specification/Core.thy
+++ b/isabelle/Doc/Specification/Core.thy
@@ -1,11 +1,11 @@
 (*<*)
 theory Core
-  imports 
+  imports
       SpecificationLatexSugar
       Core.Semantics
       Core.SemanticsTypes
 
-begin 
+begin
 (*>*)
 chapter \<open>Marlowe Core\<close>
 
@@ -115,12 +115,12 @@ list of inclusive bounds @{term bs} on the values that are acceptable. For examp
 \<close> text \<open>Choices of integers, @{term "ChoiceId c p"} are identified by the name @{term n} for the choice
 and the party @{term p} who had made the choice.\<close>
 
-text \<open>The contract is notified that a particular observation @{term b} is made via
-@{term "Notify b"}; the contract only proceeds if the observation evaluates to true. Typically
+text \<open>When a notification input is received by the contract, it evaluates each
+@{term "Notify b"} in turn until an observation @{term b} evaluates to true. Typically
 notification would be done by one of the parties, or one of their wallets acting automatically.
 Notifications also have the effect of pausing contract execution until the @{term Notify} is
 received.\<close>
-text \<open>FIXME: Address review comment "Hm, I am not sure this is accurate, the contract is notified that some Notify clause is true, the notification doesn't say which one (so not a particular one)"\<close>
+text \<open>FIXME: Carefully review and make sure we have addressed the review comments "Hm, I am not sure this is accurate, the contract is notified that some Notify clause is true, the notification doesn't say which one (so not a particular one)" and "Same here, so we should say it triggers/matches the first notify whose condition b evaluates to true (there could be several and the notify can trigger any of them)".\<close>
 
 subsection \<open>Input\<close>
 
@@ -145,7 +145,7 @@ contract. A party may be identified by a public-key hash or by a role.
 \<close>
 
 text \<open>@{term "Account p"} identifies the internal account for party @{term p}, whereas
-@{term "Party p"} identifies the internal account for that party.\<close>
+@{term "Party p"} identifies the party itself.\<close>
 
 text \<open>@{term "PubKey h"} identifies a party by the hash @{term h} of a public key, whereas
 @{term "Role n"} identifies the party by the name @{term n} of their role.
@@ -179,7 +179,7 @@ start or end of the validity interval for the Marlowe transaction.\<close>
 
 subsection \<open>Observation\label{sec:observation}\<close>
 
-text \<open>A @{type Observation} evaluates to a logical value (true or false), given the current statet
+text \<open>An @{type Observation} evaluates to a logical value (true or false), given the current statet
 of the Marlowe contract.
 @{datatype [display,names_short, margin=40]Observation}
 \<close>
@@ -189,10 +189,10 @@ the contract.\<close>
 
 text \<open>The terms @{term TrueObs} and @{term FalseObs} provide the logical constants @{value true} and
 @{value false}. The logical operators @{term "\<not> x"}, @{term "x \<and> y"},
-and @{term "x \<or> y"}are represented by the terms @{term "NotObs x"}, @{term "AndObs x y"}, and
+and @{term "x \<or> y"} are represented by the terms @{term "NotObs x"}, @{term "AndObs x y"}, and
 @{term "OrObs x y"}, respectively.\<close>
 
-text \<open>Value comparisons @{term "x < y"}, @{term "x \<le> y"}, @{term "x > y"}, @{term "x \<ge> y"},
+text \<open>Value comparisons @{term "x < y"}, @{term "x \<le> y"}, @{text "x > y"}, @{text "x \<ge> y"},
 and @{term "x = y"} are represented by @{term "ValueLT x y"}, @{term "ValueLE x y"},
 @{term "ValueGT x y"}, @{term "ValueGE x y"}, and @{term "ValueEQ x y"}.\<close>
 
@@ -211,7 +211,7 @@ text \<open>The internal state of a Marlowe contract consists of the current bal
 account, a record of the most recent value of each type of choice, a record of the most recent
 value of each variable, and the minimum time for which input can be applied to the contract. The
 data for accounts, choices, and bound values are stored as association lists.\<close>
-(* Sadly there is no antiquote to print a record, and I wasn't able to 
+(* Sadly there is no antiquote to print a record, and I wasn't able to
 make the snipet import work (described in chapter 7 of the Sugar Latex PDF).
 So to show records we need to duplicate the definition
  *)
@@ -265,8 +265,9 @@ text \<open>@{code_stmts fixInterval constant: fixInterval (Haskell)}\<close>
 
 subsection \<open>Apply All Inputs\label{sec:applyAllInputs}\<close>
 
-text \<open>The @{const applyAllInputs} function iteratively applies the transaction inputs to the state,
-checking for errors along the way and continuing until the contract reaches a quiescent state.\<close>
+text \<open>The @{const applyAllInputs} function iteratively progresses the contract and applies the
+transaction inputs to the state, checking for errors along the way and continuing until all the inputs
+are consumed and the contract reaches a quiescent state.\<close>
 text \<open>@{code_stmts applyAllInputs constant: applyAllInputs (Haskell)}\<close>
 text \<open>@{code_stmts applyAllLoop constant: applyAllLoop (Haskell)}\<close>
 
@@ -285,13 +286,15 @@ text \<open>@{code_stmts reductionLoop constant: reductionLoop (Haskell)}\<close
 
 subsection \<open>Reduce Contract Step\label{sec:reducecontractstep}\<close>
 
-text \<open>The @{const reduceContractStep} function handles is @{type Contract} case, performing the
-relevant action (payments, state-change, etc.), reporting warning and throwing errors if needed.\<close>
+text \<open>The @{const reduceContractStep} function handles the progression of the @{type Contract} in
+the absence of inputs: it performs the relevant action (payments, state-change, etc.), reports warnings,
+ and throws errors if needed. It stops reducing the contract at the point when the contract requires
+external input.\<close>
 text \<open>@{code_stmts reduceContractStep constant: reduceContractStep (Haskell)}\<close>
 
 subsection \<open>Apply Input\label{sec:applyinput}\<close>
 
-text \<open>The @{const applyInput} function attempts to apply the next input each @{term Case} in the
+text \<open>The @{const applyInput} function attempts to apply the next input to each @{term Case} in the
 @{term When}, in sequence.\<close>
 text \<open>@{code_stmts applyInput constant: applyInput (Haskell)}\<close>
 
@@ -317,7 +320,7 @@ text \<open>@{code_stmts refundOne constant: refundOne (Haskell)}\<close>
 subsection \<open>Evaluate Value\label{sec:evalvalue}\<close>
 
 text \<open>Given the \hyperref[sec:environment]{@{typ Environment}} and the current
- \hyperref[sec:state]{@{typ State}}, the @{const evalValue} function 
+ \hyperref[sec:state]{@{typ State}}, the @{const evalValue} function
 evaluates a \hyperref[sec:value]{@{typ Value}} into a number\<close>
 
 text \<open>@{const evalValue} :: @{typeof evalValue}\<close>
@@ -350,13 +353,13 @@ text \<open>@{thm evalAddCommutative}\<close>
 subsubsection \<open>Subtraction\<close>
 
 text \<open>For the \<^emph>\<open>SubValue\<close> case, @{const evalValue} will evaluate both sides and subtract
-the second value to the first.\<close>
+the second value from the first.\<close>
 
 text \<open>@{thm evalValue_SubValue}\<close>
 
 subsubsection \<open>Negation\<close>
 
-text \<open>For every value \<^emph>\<open>val\<close> there is the complement \<^emph>\<open>NegValue val\<close> so that\<close>
+text \<open>For every value \<^emph>\<open>x\<close> there is the complement \<^emph>\<open>NegValue x\<close> so that\<close>
 
 text \<open>@{thm evalNegValue}\<close>
 
@@ -368,7 +371,7 @@ text \<open>@{thm evalValue_MulValue}\<close>
 
 subsubsection \<open>Division\<close>
 
-text \<open>Division is a special case because we only evaluate to natural numbers: 
+text \<open>Division is a special case because we only evaluate to natural numbers:
 \<^item> If the denominator is 0, the result is also 0. Other languages uses NaN or Infinity to represent this case
 \<^item> The result will be rounded towards zero.\<close>
 
@@ -416,7 +419,7 @@ text \<open>@{thm evalValue_Cond}\<close>
 subsection \<open>Evaluate Observation\label{sec:evalobservation}\<close>
 
 text \<open>Given the \hyperref[sec:environment]{@{typ Environment}} and the current
- \hyperref[sec:state]{@{typ State}}, the @{const evalObservation} function 
+ \hyperref[sec:state]{@{typ State}}, the @{const evalObservation} function
 evaluates an \hyperref[sec:observation]{@{typ Observation}} into a number\<close>
 
 text \<open>@{const evalObservation} :: @{typeof evalObservation}\<close>

--- a/isabelle/Doc/Specification/Core.thy
+++ b/isabelle/Doc/Specification/Core.thy
@@ -11,16 +11,127 @@ chapter \<open>Marlowe Core\<close>
 
 section \<open>Types\<close>
 
+text \<open>The Marlowe core types define the Marlowe DSL: @{type Contract} defines Marlowe contracts,
+@{type State} tracks the state variables of such contracts, and @{type Environment} specifies the
+execution environment for contracts.\<close>
+
+text \<open>FIXME: Figure out how to prevent erasure of type synonyms in the antiquotations in this
+section.\<close>
+
 subsection \<open>Contract\<close>
-text \<open>@{datatype [display,names_short, margin=40]Contract}\<close>
+
+text \<open>The simplest contract, @{term Close}, has completed its execution; other contracts include
+one or more continuations for subsequent contract(s). The @{term When} and
+@{term If} contracts branch on conditions. The @{term Pay} contract makes a payment to a
+@{type Payee}. A @{term Let} contract assigns a value to a variable and an @{term Assert} contract
+make an assertion about the contract's state that a particular condition should hold at that point
+in the contract.
+@{datatype [display,names_short, margin=40]Contract}
+\<close>
+
+text \<open>A contract @{term Close} provides for the contract to be closed (or terminated). The only
+action that it performs is to provide refunds to the owners of accounts that contain a positive
+balance. This is performed one account per step, but all accounts will be refunded in a single
+transaction.\<close>
+
+text \<open>A payment contract @{term "Pay a p t v c"} will make a payment of
+value @{term v} of token @{term t} from the account @{term a} to a payee
+@{term p}, which will be one of the contract participants or another account in the contract.
+Warnings will be generated if the value v is negative, or if there is not enough in the account to
+make the payment in full (even if there are positive balances of other tokens in the account). In
+the latter case, a partial payment (of all the money available) is made. The continuation contract
+is the one given in the contract: @{term c}.\<close>
+
+text \<open>The conditional @{term "If b c1 c2"} will continue as
+@{term c1} or @{term c2}, depending on the Boolean value of the observation
+@{term b} when this construct is executed.\<close>
+
+text \<open>@{term When} is the most complex constructor for contracts, with the form
+@{term "When cs t c"}. It is a contract that is triggered on actions, which may
+or may not happen at any particular time: what happens when various actions happen is described by
+the cases in the contract. The list @{term cs} contains a collection of cases providing input to
+the contract: the first case that is satisfied by external input is the one that is executed. In
+order to make sure that the contract makes progress eventually, the contract will continue as
+@{term c} when the @{term t}, a POSIX time, is reached.\<close>
+
+text \<open>A @{term Let} contract @{term "Let i v c"} allows a contract to name a
+value using an identifier @{term i}. In this case, the expression @{term v} is
+evaluated, and stored with the name @{term i}. The contract then continues as
+@{term c}. As well as allowing us to use abbreviations, this mechanism also means that we
+can capture and save volatile values that might be changing with time, e.g. the current price of
+oil, or the current time, at a particular point in the execution of the contract, to be used later
+on in contract execution.
+@{datatype [display,names_short, margin=40]ValueId}
+\<close>
+
+text \<open>An assertion contract @{term "Assert b c"} does not have any effect on
+the state of the contract, it immediately continues as @{term c}, but it issues a warning
+when the observation @{term b} is false. It can be used to ensure that a property holds
+in any given point of the contract, since static analysis will fail if any execution causes a
+warning.\<close>
+
+subsection \<open>Case and Action\label{sec:case}\<close>
+
+text \<open>The @{term Case} is used in @{term When} clauses to branch on input conditions or timeouts.
+External inputs take the form of @{term Action}.
+@{datatype [display,names_short, margin=40]Case}
+\<close>
+
+text \<open>Each case has the form @{term "Case a c"} where @{term a} is the external
+input (an action) and @{term c} a continuation to another contract. When a particular action, e.g.
+@{term a}, happens, the state is updated accordingly and the contract will continue as the
+corresponding continuation @{term c}.\<close>
+
+text \<open>Three kinds of action are possible: deposits, choices, and notifications.
+@{datatype [display,names_short, margin=40]Action}
+\<close>
+
+text \<open>A @{term "Deposit a p t v"} makes a deposit of value @{term v} of token @{term t} from party
+@{term p} into account @{term a}.\<close>
+
+text \<open>A choice @{term "Choice i bs"} is made for a particular choice identified by @{term i}  with a
+list of inclusive bounds @{term bs} on the values that are acceptable. For example,
+@{text "[Bound 0 0, Bound 3 5]"} offers the choice of one of 0, 3, 4 and 5.
+@{term [display,names_short, margin=40]Bound}
+@{datatype [display,names_short, margin=40]ChoiceId}
+@{term [display,names_short, margin=40]ChoiceName}
+Choices of integers, @{term "ChoiceId c p"} are identified by the name @{term n} for the choice
+and the party @{term p} who had made the choice.\<close>
+
+text \<open>The contract is notified that a particular observation @{term b} is made via
+@{term "Notify b"}; the contract only proceeds if the observation evaluates to true. Typically
+notification would be done by one of the parties, or one of their wallets acting automatically.
+Notifications also have the effect of pausing contract execution until the @{term Notify} is
+received.\<close>
+
+subsection \<open>Party and Payee\label{sec:party}\<close>
+
+text \<open>A payment can be made to one of the parties to the contract, or to one of the accounts of the
+contract. A party may be identified by a public-key hash or by a role.
+@{datatype [display,names_short, margin=40]Payee}
+@{datatype [display,names_short, margin=40]Party}
+\<close>
+
+text \<open>@{term "Account p"} identifies the internal account for party @{term p}, whereas
+@{term "Party p"} identifies the internal account for that party.\<close>
+
+text \<open>@{term "PubKey h"} identifies a party by the hash @{term h} of a public key, whereas
+@{term "Role n"} identifies the party by the name @{term n} of their role.\<close>
+
+text \<open>\<close>
+
 
 subsection \<open>Value\label{sec:value}\<close>
 text \<open>@{datatype [display,names_short, margin=40]Value}\<close>
+
+subsection \<open>Observation\label{sec:observation}\<close>
+text \<open>@{datatype [display,names_short, margin=40]Observation}\<close>
 
 subsection \<open>Input\<close>
 text \<open>@{datatype [display,names_short, margin=40]Input}\<close>
 
 subsection \<open>State\label{sec:state}\<close>
+text \<open>FIXME: Figure out how to display records via antiquotation.\<close>
 (* Sadly there is no antiquote to print a record, and I wasn't able to 
 make the snipet import work (described in chapter 7 of the Sugar Latex PDF).
 So to show records we need to duplicate the definition
@@ -32,8 +143,16 @@ record State = accounts :: Accounts
 
 subsection \<open>Environment\label{sec:environment}\<close>
 
-
+text \<open>FIXME: Figure out how to display records via antiquotation.\<close>
 record Environment = timeInterval :: TimeInterval
+
+
+subsection \<open>Token\label{sec:token}\<close>
+text \<open>@{datatype [display,names_short, margin=40]Token}\<close>
+
+subsection \<open>Type Synonyms\label{sec:synonyms}\<close>
+text \<open>FIXME: Figure out how to display type synonyms here.\<close>
+
 
 section \<open>Semantics\<close>
 

--- a/isabelle/Doc/Specification/Core.thy
+++ b/isabelle/Doc/Specification/Core.thy
@@ -22,6 +22,20 @@ text \<open>FIXME: Figure out how to emit Isabelle instead of Haskell in "code s
 
 subsection \<open>Contract\<close>
 
+text \<open>FIXME, review comment:
+
+After we show the datatype we already say what each construct does, maybe as a prelude we could say something like:
+
+A Marlowe Contract can be one of these constructs, Close being the simplest, and the only one that doesn't carry a continuation. All Contracts eventually will end up with a Close construct.
+
+the datatype
+
+Close: details
+Pay: details
+etc
+
+\<close>
+
 text \<open>The simplest contract, @{term Close}, has completed its execution; other contracts include
 one or more continuations for subsequent contract(s). The @{term When} and
 @{term If} contracts branch on conditions. The @{term Pay} contract makes a payment to a
@@ -40,7 +54,7 @@ transaction.\<close>
 text \<open>A payment contract @{term "Pay a p t v c"} will make a payment of
 value @{term v} of token @{term t} from the account @{term a} to a payee
 @{term p}, which will be one of the contract participants or another account in the contract.
-Warnings will be generated if the value v is negative, or if there is not enough in the account to
+Warnings will be generated if the value @{term v} is negative, or if there is not enough in the account to
 make the payment in full (even if there are positive balances of other tokens in the account). In
 the latter case, a partial payment (of all the money available) is made. The continuation contract
 is the one given in the contract: @{term c}.\<close>
@@ -71,7 +85,7 @@ text \<open>An assertion contract @{term "Assert b c"} does not have any effect 
 the state of the contract, it immediately continues as @{term c}, but it issues a warning
 when the observation @{term b} is false. It can be used to ensure that a property holds
 in any given point of the contract, since static analysis will fail if any execution causes a
-warning.\<close>
+warning. the @{term Assert} term might be removed from future on-chain versions of Marlowe.\<close>
 
 subsection \<open>Case and Action\label{sec:case}\<close>
 
@@ -106,6 +120,7 @@ text \<open>The contract is notified that a particular observation @{term b} is 
 notification would be done by one of the parties, or one of their wallets acting automatically.
 Notifications also have the effect of pausing contract execution until the @{term Notify} is
 received.\<close>
+text \<open>FIXME: Address review comment "Hm, I am not sure this is accurate, the contract is notified that some Notify clause is true, the notification doesn't say which one (so not a particular one)"\<close>
 
 subsection \<open>Input\<close>
 
@@ -242,9 +257,10 @@ text \<open>@{code_stmts computeTransaction constant: computeTransaction (Haskel
 subsection \<open>Fix Interval\<close>
 
 text \<open>The @{const fixInterval} functions combines the minimum-time constraint of @{term State}
-with the time interval of @{term Environment} to yield a "trimmed" validity interval and a minimum
+with the time interval of @{term Environment} to yield a ``trimmed'' validity interval and a minimum
 time for the new state that will result from applying the transaction. It throws an error if the
 interval is nonsensical or in the past.\<close>
+text \<open>FIXME: print type synonym: @{term [names_short, margin=40]IntervalResult}\<close>
 text \<open>@{code_stmts fixInterval constant: fixInterval (Haskell)}\<close>
 
 subsection \<open>Apply All Inputs\label{sec:applyAllInputs}\<close>
@@ -257,7 +273,7 @@ text \<open>@{code_stmts applyAllLoop constant: applyAllLoop (Haskell)}\<close>
 subsection \<open>Reduce Contract Until Quiescent\label{sec:reduceContractUntilQuiescent}\<close>
 
 text \<open>The @{const reduceContractUntilQuiescent} executes as many non-input steps of the contract as
-is possible.\<close>
+is possible. Marlowe semantics do not allow partial execution of a series of non-input steps.\<close>
 text \<open>@{code_stmts reduceContractUntilQuiescent constant: reduceContractUntilQuiescent (Haskell)}\<close>
 
 subsection \<open>Reduction Loop\label{sec:reductionloop}\<close>
@@ -286,7 +302,7 @@ compute the new contract state, emit warnings, throw errors if needed, and deter
 continuation of the contract.\<close>
 text \<open>@{code_stmts applyCases constant: applyCases (Haskell)}\<close>
 
-subsection \<open>Account Utilitiesn\label{sec:accountutilities}\<close>
+subsection \<open>Utilitiesn\label{sec:accountutilities}\<close>
 
 text \<open>The @{const moneyInAccount}, @{const updateMoneyInAccount}, and @{const addMoneyToAccount}
 functions read, write, and increment the funds in a particular account of the @{term State},
@@ -353,7 +369,6 @@ text \<open>@{thm evalValue_MulValue}\<close>
 subsubsection \<open>Division\<close>
 
 text \<open>Division is a special case because we only evaluate to natural numbers: 
-\<^item> If the numerator is 0, the denominator is not evaluated and the result is 0
 \<^item> If the denominator is 0, the result is also 0. Other languages uses NaN or Infinity to represent this case
 \<^item> The result will be rounded towards zero.\<close>
 

--- a/isabelle/Doc/Specification/Guarantees.thy
+++ b/isabelle/Doc/Specification/Guarantees.thy
@@ -1,14 +1,14 @@
 (*<*)
 theory Guarantees
-  imports       
-      Core.SemanticsTypes 
-      Core.MoneyPreservation 
+  imports
+      Core.SemanticsTypes
+      Core.MoneyPreservation
       Core.Timeout
       Core.QuiescentResult
       Core.SingleInputTransactions
       Core.CloseSafe
       Core.TransactionBound
- 
+
 begin
 (*>*)
 
@@ -101,7 +101,7 @@ The following always produce quiescent contracts:
 \item reduceContractUntilQuiescent \secref{sec:reduceContractUntilQuiescent}
 \item applyAllInputs  \secref{sec:applyAllInputs}
 \item computeTransaction  \secref{sec:computeTransaction}
-\item playTrace  \secref{sec:playTrace} 
+\item playTrace  \secref{sec:playTrace}
 \end{itemize}
 \<close>
 

--- a/isabelle/Doc/Specification/Guarantees.thy
+++ b/isabelle/Doc/Specification/Guarantees.thy
@@ -38,7 +38,7 @@ text \<open>
 One of the dangers of using smart contracts is that a badly written one can potentially lock its
 funds forever. By the end of the contract, all the money paid to the contract must be distributed
 back, in some way, to a subset of the participants of the contract. To ensure this is the case we
-proved two properties: "Money Preservation" and "Contracts Always Close".
+proved two properties: ``Money Preservation'' and ``Contracts Always Close''.
 
 Regarding money preservation, money is not created or destroyed by the semantics. More specifically,
 the money that comes in plus the money in the contract before the transaction must be equal to the
@@ -80,6 +80,7 @@ We call a value for State valid if the first two properties are true. And we say
 accounts if the third property is true.
 
 \<close>
+text \<open>FIXME: Address the review comment "Is this a note for us or the explanation to the user of what @{term playTraceAux_preserves_validAndPositive_state} proves?".\<close>
 
 text \<open>@{thm playTraceAux_preserves_validAndPositive_state}\<close>
 
@@ -108,7 +109,8 @@ text \<open>@{thm playTraceIsQuiescent}\<close>
 
 section \<open>Reducing a Contract until Quiescence Is Idempotent\<close>
 
-text \<open>Once a contract is quiescent, further reduction will not change the contract or state.\<close>
+text \<open>Once a contract is quiescent, further reduction will not change the contract or state,
+and it will not produce any payments or warnings.\<close>
 
 text \<open>@{thm reduceContractUntilQuiescentIdempotent}\<close>
 
@@ -125,7 +127,8 @@ text \<open>
 
 Isabelle automatically proves termination for most function. However, this is not the case for
 @{const reductionLoop}, but it is manually proved that the reduction loop monotonically reduces the
-size of the contract, which is sufficient to prove termination.
+size of the contract (except for @{term Close}, which reduces the number of accounts), this is
+sufficient to prove termination.
 
 @{thm reduceContractStepReducesSize}
 

--- a/isabelle/Doc/Specification/Guarantees.thy
+++ b/isabelle/Doc/Specification/Guarantees.thy
@@ -3,70 +3,153 @@ theory Guarantees
   imports       
       Core.SemanticsTypes 
       Core.MoneyPreservation 
+      Core.Timeout
       Core.QuiescentResult
       Core.SingleInputTransactions
-      Core.Timeout
+      Core.CloseSafe
       Core.TransactionBound
  
 begin
 (*>*)
 
 chapter \<open>Marlowe Guarantees\<close>
-text \<open>TODO: add human readable version of the important theorems and lemmas\<close>
+
+text \<open>We can also use proof assistants to demonstrate that the Marlowe semantics presents certain
+desirable properties, such as that money is preserved and anything unspent is returned to users by
+the end of the execution of any contract.\<close>
+
+subsubsection \<open>Auxillary Functions\label{sec:playTrace}\<close>
+
+text \<open>Many of the proofs in this chapter rely on function @{const playTrace} and
+@{const playTraceAux} that execute a sequence of transactions using the Marlowe semantics defined in
+@{const computeTransaction}. They also rely on starting from a valid and positive contract state,
+@{const validAndPositive_state} and a function @{const maxTimeContract} that extracts the latest
+timeout from the contract.\<close>
+
+text \<open>@{const playTrace} :: @{typeof playTrace}\<close>
+text \<open>@{const playTraceAux} :: @{typeof playTraceAux}\<close>
+text \<open>@{const validAndPositive_state} :: @{typeof validAndPositive_state}\<close>
+text \<open>@{const maxTimeContract} :: @{typeof maxTimeContract}\<close>
 
 section \<open>Money Preservation\<close>
-text \<open>TODO: Money preservation\<close>
-text \<open>@{thm playTrace_preserves_money}\<close>
 
-section \<open>Positive Accounts\<close>
-text \<open>TODO: Positive accounts\<close>
-text \<open>@{thm playTraceAux_preserves_validAndPositive_state}\<close>
+text \<open>
 
-section \<open>Quiescent Result\<close>
-text \<open>TODO: definition of Quiescent\<close>
-text
-\<open>
-The following always produce quiescent contracts:
-\<^item> reductionLoop \secref{sec:reductionloop}
-\<^item> reduceContractUntilQuiescent \secref{sec:reduceContractUntilQuiescent}
-\<^item> applyAllInputs  \secref{sec:applyAllInputs}
-\<^item> computeTransaction  \secref{sec:computeTransaction}
-\<^item> playTrace  \secref{sec:playTrace} 
+One of the dangers of using smart contracts is that a badly written one can potentially lock its
+funds forever. By the end of the contract, all the money paid to the contract must be distributed
+back, in some way, to a subset of the participants of the contract. To ensure this is the case we
+proved two properties: "Money Preservation" and "Contracts Always Close".
+
+Regarding money preservation, money is not created or destroyed by the semantics. More specifically,
+the money that comes in plus the money in the contract before the transaction must be equal to the
+money that comes out plus the contract after the transaction, except in the case of an error.
+
 \<close>
 
-text \<open>@{thm playTraceIsQuiescent}\<close>
-text \<open>TODO: explanation of theorem\<close>
+text \<open>@{thm playTrace_preserves_money}\<close>
 
-section \<open>reduceContractUntilQuiescent is idempotent\<close>
-text \<open>TODO: explain\<close>
-text \<open>@{thm reduceContractUntilQuiescentIdempotent }\<close>
-
-section \<open>Split Transactions Into Single Input Does Not Affect the Result\<close>
-text \<open>TODO: explain\<close>
-text \<open>@{thm playTraceAuxToSingleInputIsEquivalent }\<close>
-
+text \<open>where @{const moneyInTransactions} and @{const moneyInPlayTraceResult} measure the funds in
+the transactions applied to a contract versus the funds in the contract state and the payments that
+it has made while executing.\<close>
 
 section \<open>Contracts Always Close\<close>
 
-text \<open>TODO: proofs around contracts always close and Funds are not held after it close\<close>
-(* Do we have or need a lemma that accounts are empty after close? *)
+text \<open>
+
+For every Marlowe Contract there is a time after which an empty transaction can be issued that will
+close the contract and refund all the money in its accounts.
+
+FIXME: This theorem doesn't actually prove the narrative. Are we missing a theorem?
+
+\<close>
+
+text \<open>@{thm timeOutTransaction_closes_contract2}\<close>
+
+section \<open>Positive Accounts\<close>
+
+text \<open>
+
+There are some values for State that are allowed by its type but make no sense, especially in the
+case of Isabelle semantics where we use lists instead of maps:
+\begin{enumerate}
+\item The lists represent maps, so they should have no repeated keys.
+\item We want two maps that are equal to be represented the same, so we force keys to be in ascending order.
+\item We only want to record those accounts that contain a positive amount.
+\end{enumerate}
+We call a value for State valid if the first two properties are true. And we say it has positive
+accounts if the third property is true.
+
+\<close>
+
+text \<open>@{thm playTraceAux_preserves_validAndPositive_state}\<close>
+
+section \<open>Quiescent Result\<close>
+
+text \<open>
+
+A contract is quiescent if and only if the root construct is @{term When}, or if the contract is
+@{term Close} and all accounts are empty. If an input @{term State} is valid and accounts are
+positive, then the output will be quiescent, @{const isQuiescent}.
+\<close>
+
+text \<open>
+
+The following always produce quiescent contracts:
+\begin{itemize}
+\item reductionLoop \secref{sec:reductionloop}
+\item reduceContractUntilQuiescent \secref{sec:reduceContractUntilQuiescent}
+\item applyAllInputs  \secref{sec:applyAllInputs}
+\item computeTransaction  \secref{sec:computeTransaction}
+\item playTrace  \secref{sec:playTrace} 
+\end{itemize}
+\<close>
+
+text \<open>@{thm playTraceIsQuiescent}\<close>
+
+section \<open>Reducing a Contract until Quiescence Is Idempotent\<close>
+
+text \<open>Once a contract is quiescent, further reduction will not change the contract or state.\<close>
+
+text \<open>@{thm reduceContractUntilQuiescentIdempotent}\<close>
+
+section \<open>Split Transactions Into Single Input Does Not Affect the Result\<close>
+
+text \<open>Applying a list of inputs to a contract produces the same result as applying each input
+singly.\<close>
+
+text \<open>@{thm playTraceAuxToSingleInputIsEquivalent }\<close>
 
 subsection \<open>Termination Proof\<close>
-text \<open>TODO: adapt text from section 5.1 "Termination proof" from the 
-2019 paper.\<close>
+
+text \<open>
+
+Isabelle automatically proves termination for most function. However, this is not the case for
+@{const reductionLoop}, but it is manually proved that the reduction loop monotonically reduces the
+size of the contract, which is sufficient to prove termination.
+
+@{thm reduceContractStepReducesSize}
+
+\<close>
 
 subsection \<open>All Contracts Have a Maximum Time\<close>
-text \<open>If we send an empty transaction with time equal to maxTimeContract, the contract will close\<close>
-text \<open>TODO: explain\<close>
+
+text \<open>If one sends an empty transaction with time equal to @{const maxTimeContract}, then the
+contract will close.\<close>
+
 text \<open>@{thm [mode=Rule,names_short] timedOutTransaction_closes_contract}\<close>
 
 subsection \<open>Contract Does Not Hold Funds After it Closes\<close>
-text \<open>TODO: Funds are not held after it close\<close>
+
+text \<open>Funds are not held in a contract after it closes.\<close>
+
+text \<open>@{thm closeIsSafe}\<close>
 
 subsection \<open>Transaction Bound\<close>
-text \<open>There is a maximum number of transaction that can be accepted by a contract\<close>
+
+text \<open>There is a maximum number of transaction that can be accepted by a contract.\<close>
 
 (* should we have a maxTransactions :: Contract \<Rightarrow> Int in the semantics? *)
+
 text \<open>@{thm playTrace_only_accepts_maxTransactionsInitialState}\<close>
 
 (*<*)

--- a/isabelle/Doc/Specification/Specification.thy
+++ b/isabelle/Doc/Specification/Specification.thy
@@ -9,19 +9,139 @@ chapter \<open>Marlowe\<close>
 
 section \<open>Introduction\<close>
 
-text \<open>TODO: small introduction on Marlowe\<close>
-text \<open>TODO: description of each chapter\<close>
+text \<open>
 
-section \<open>The Marlowe Model\<close>
-text \<open>TODO: Add parts of the section "The Marlowe Model" from the
-2019 paper that helps introduce Marlowe. 
-The paper starts describing some of the data types, in here I would 
-point to the Marlowe Core Data Types instead with more in depth description
+Marlowe is a special purpose or domain-specific language (DSL) that is designed to be usable by
+someone who is expert in the field of financial contracts, rather than requiring programming skills
+to use it.
 
-I would also add a Note of internal accounts here.
+Marlowe is modelled on special-purpose financial contract languages popularised in the last decade
+or so by academics and enterprises such as LexiFi, which provides contract software in the financial
+sector. In developing Marlowe, we have adapted these languages to work on blockchain. Marlowe was
+first implemented on the Cardano blockchain, but it could equally well be implemented on Ethereum or
+other blockchain platforms; in this respect it is “platform agnostic” just like modern programming
+languages such as Java and C++.
+
+Where we differ from non-blockchain approaches is in how we make sure that the contract is followed.
+This means not only that the instructions of the contract are not disobeyed – “nothing bad happens”
+– but also that the participants participate and don’t walk away early, leaving money locked up in
+the contract forever: “good things actually happen”. We do this using timeouts.
+
+A contract can ask a participant to make a deposit of some funds, but obviously the contract cannot
+actually force a participant to make a deposit. Instead, the contract can wait for a period of time
+for the participant to commit to the contract: when that period of time expires, the contract moves
+on to follow some alternative instructions. This prevents a participant stopping a contract by not
+taking part, thus making sure that “things happen”.
+
+All the constructs of Marlowe that require user participation – including user deposits and user
+choices – are protected by timeouts. Because of this, it is easy to see that the commitment made by
+a participant to a contract is finite: we can predict when the contract will have nothing left to do
+– when it can be closed. At this point any unspent funds left in the contract are refunded to
+participants, and the contract stops, or terminates. So, any funds put into the contract by a
+participant can’t be locked up forever: at this point the commitment effectively ends.
+
+What is more, it is easy for us to read off from the contract when it will terminate, we call this
+the lifetime of the contract: all participants will therefore be able to find out this lifetime
+before taking part in any contract,
+
+In our model, a running contract cannot force a deposit or a choice to happen: all it can do is to
+request a deposit or choice from a participant. In other words, for these actions it cannot “push”,
+but it can “pull”. On the other hand, it can make payments automatically, so some aspects of a
+Marlowe contract can “push” to make some things happen, e.g. ensuring that a payment is made to a
+participant by constructing an appropriate transaction output.
 
 \<close>
 
+text \<open>
+
+The first chapter of the document provides an overview of the Marlowe DSL and semantics. The
+following chapter defines the language and semantics in detail. The third, final chapter presents
+proofs that guarantee that Marlowe contracts possess properties desirable for financial agreements.
+
+\<close>
+
+section \<open>The Marlowe Model\<close>
+
+text \<open>
+
+Marlowe is designed to support the execution of financial contracts on blockchain, and specifically
+to work on Cardano. Contracts are built by putting together a small number of constructs that can be
+combined to describe many different kinds of financial contract.
+
+Before we describe those constructs, we need to look at our general approach to modelling contracts
+in Marlowe, and the context in which Marlowe contracts are executed, the Cardano blockchain. In
+doing this we also introduce some of the terminology that we will use, indicating definitions by
+italics.
+
+\<close>
+
+subsection \<open>Contracts\<close>
+
+text \<open>
+
+Contracts in Marlowe run on a blockchain, but need to interact with the off-chain world. The parties
+to the contract, whom we also call the participants, can engage in various actions: they can be
+asked to deposit money, or to make a choice between various alternatives. Notification is another
+form of input that is used to tell the contract that a certain condition has been met, anybody can
+do this, and it is only necessary because once a contract becomes dormant (quiescent), it cannot
+“wake up” on its own, it can only respond to inputs.
+
+Running a contract may also produce external effects, by making payments to parties in the contract.
+
+\<close>
+
+subsection \<open>Participants, roles, and public key\<close>
+
+text \<open>
+
+We should separate the notions of participant, role, and public keys in a Marlowe contract. A
+participant (or party) in the contract can be represented by either a role or a public key (public
+keys will eventually be replaced by addresses).
+
+Roles are represented by tokens and they are distributed to addresses at the time a contract is
+deployed to the blockchain. After that, whoever has the token representing a role is able to carry
+out the actions assigned to that role, and receive the payments that are issued to that role.
+
+Public key parties, are represented by the hash of a public key (or eventually an addresses). Using
+public keys to represent parties is simpler because it does not require handling tokens, but they
+cannot be traded, because once you know the private key for a given public key you cannot prove you
+have forgotten it.
+
+\<close>
+
+subsection \<open>Accounts\<close>
+
+text \<open>
+
+The Marlowe model allows for a contract to store assets. All parties that participate in the
+contract implicitly own an account with their name. All assets stored in the contract must be in
+an internal account for one of the parties; this way, when the contract is closed, all assets that
+remain in the contract belong to someone, and so can be refunded to their respective owners. These
+accounts are local: they only exist within the contract and for the duration of the execution of the
+contract, and during that time they are only accessible from within the contract. During the course
+of the contract payments may be made into accounts (as deposits), between accounts (as internal
+ transfers), or out from accounts (as external payments).
+
+\<close>
+
+subsection \<open>Steps and states\<close>
+
+text \<open>
+
+Marlowe contracts describe a series of steps, typically by describing the first step, together with
+another (sub-) contract that describes what to do next. For example, the contract
+@{term "Pay a p t v c"} says “make a payment of value @{term v} of token @{term t} to the party
+@{term p} from the account @{term a}, and then follow the contract @{term c}”. We call @{term c} the
+continuation of the contract.
+
+In executing a contract, we need to keep track of the current contract (that is, the remaining part
+of the contract): after making a step in the example above, the current contract is the
+continuation, @{term c}. We also have to keep track of some other information, such as how much is
+held in each account: we call this information the state, and this potentially changes at each step,
+too. A step can also see an action taking place, such as money being deposited, or an effect being
+produced, e.g. a payment.
+
+\<close>
 
 (*<*)
 end

--- a/isabelle/Doc/Specification/Specification.thy
+++ b/isabelle/Doc/Specification/Specification.thy
@@ -2,7 +2,7 @@
 theory Specification
   imports Main
 
-begin                                                     
+begin
 (*>*)
 
 chapter \<open>Marlowe\<close>

--- a/isabelle/Doc/Specification/Specification.thy
+++ b/isabelle/Doc/Specification/Specification.thy
@@ -12,43 +12,45 @@ section \<open>Introduction\<close>
 text \<open>
 
 Marlowe is a special purpose or domain-specific language (DSL) that is designed to be usable by
-someone who is expert in the field of financial contracts, rather than requiring programming skills
-to use it.
+someone who is expert in the field of financial contracts, somewhat lessening the need for
+programming skills.
 
 Marlowe is modelled on special-purpose financial contract languages popularised in the last decade
 or so by academics and enterprises such as LexiFi, which provides contract software in the financial
 sector. In developing Marlowe, we have adapted these languages to work on blockchain. Marlowe was
-first implemented on the Cardano blockchain, but it could equally well be implemented on Ethereum or
-other blockchain platforms; in this respect it is “platform agnostic” just like modern programming
-languages such as Java and C++.
+implemented on the Cardano blockchain, but is designed to be blockchain agnostic. The same way that
+modern languages like C++ and Java has compilers that target intel/ARM, Marlowe could be implemented
+in Ethereum and other blockchain platforms.
 
 Where we differ from non-blockchain approaches is in how we make sure that the contract is followed.
-This means not only that the instructions of the contract are not disobeyed – “nothing bad happens”
-– but also that the participants participate and don’t walk away early, leaving money locked up in
-the contract forever: “good things actually happen”. We do this using timeouts.
+This means not only that the instructions of the contract are not disobeyed---``nothing bad
+---happens'' but also that the participants don't walk away early, leaving money locked up in the
+contract forever: ``good things actually happen''. We do this using timeouts.
 
 A contract can ask a participant to make a deposit of some funds, but obviously the contract cannot
 actually force a participant to make a deposit. Instead, the contract can wait for a period of time
 for the participant to commit to the contract: when that period of time expires, the contract moves
 on to follow some alternative instructions. This prevents a participant stopping a contract by not
-taking part, thus making sure that “things happen”.
+taking part, thus making sure that ``things happen''.
 
-All the constructs of Marlowe that require user participation – including user deposits and user
-choices – are protected by timeouts. Because of this, it is easy to see that the commitment made by
-a participant to a contract is finite: we can predict when the contract will have nothing left to do
-– when it can be closed. At this point any unspent funds left in the contract are refunded to
+All the constructs of Marlowe that require user participation---including user deposits and user
+choices---are protected by timeouts. Because of this, it is easy to see that the commitment made by
+a participant to a contract is finite: we can predict when the contract will have nothing left to
+do---when it can be closed. At this point any unspent funds left in the contract are refunded to
 participants, and the contract stops, or terminates. So, any funds put into the contract by a
-participant can’t be locked up forever: at this point the commitment effectively ends.
+participant can't be locked up forever: at this point the commitment effectively ends.
 
 What is more, it is easy for us to read off from the contract when it will terminate, we call this
 the lifetime of the contract: all participants will therefore be able to find out this lifetime
 before taking part in any contract,
 
 In our model, a running contract cannot force a deposit or a choice to happen: all it can do is to
-request a deposit or choice from a participant. In other words, for these actions it cannot “push”,
-but it can “pull”. On the other hand, it can make payments automatically, so some aspects of a
-Marlowe contract can “push” to make some things happen, e.g. ensuring that a payment is made to a
-participant by constructing an appropriate transaction output.
+request a deposit or choice from a participant. In other words, for these actions it cannot ``push'',
+but it can ``pull''. On the other hand, it can make payments automatically, so some aspects of a
+Marlowe contract can ``push'' to make some things happen, e.g. ensuring that a payment is made to a
+participant by constructing an appropriate transaction output. FIXME: Does this paragraph make clear
+that the contracts aren't continuously running on the blockchain, but instead need to be advanced
+forward by participants submitting transactions?
 
 \<close>
 
@@ -64,14 +66,9 @@ section \<open>The Marlowe Model\<close>
 
 text \<open>
 
-Marlowe is designed to support the execution of financial contracts on blockchain, and specifically
-to work on Cardano. Contracts are built by putting together a small number of constructs that can be
-combined to describe many different kinds of financial contract.
-
-Before we describe those constructs, we need to look at our general approach to modelling contracts
-in Marlowe, and the context in which Marlowe contracts are executed, the Cardano blockchain. In
-doing this we also introduce some of the terminology that we will use, indicating definitions by
-italics.
+Marlowe is designed to support the execution of financial agreements on blockchain (initially
+Cardano), and specifically to work on Cardano. Contracts are built by putting together a small
+number of constructs that can be combined to describe many different kinds of financial contract.
 
 \<close>
 
@@ -84,7 +81,7 @@ to the contract, whom we also call the participants, can engage in various actio
 asked to deposit money, or to make a choice between various alternatives. Notification is another
 form of input that is used to tell the contract that a certain condition has been met, anybody can
 do this, and it is only necessary because once a contract becomes dormant (quiescent), it cannot
-“wake up” on its own, it can only respond to inputs.
+``wake up'' on its own, it can only respond to inputs.
 
 Running a contract may also produce external effects, by making payments to parties in the contract.
 
@@ -130,8 +127,8 @@ text \<open>
 
 Marlowe contracts describe a series of steps, typically by describing the first step, together with
 another (sub-) contract that describes what to do next. For example, the contract
-@{term "Pay a p t v c"} says “make a payment of value @{term v} of token @{term t} to the party
-@{term p} from the account @{term a}, and then follow the contract @{term c}”. We call @{term c} the
+@{term "Pay a p t v c"} says ``make a payment of value @{term v} of token @{term t} to the party
+@{term p} from the account @{term a}, and then follow the contract @{term c}''. We call @{term c} the
 continuation of the contract.
 
 In executing a contract, we need to keep track of the current contract (that is, the remaining part


### PR DESCRIPTION
Pre-audit draft of Marlowe specification. See [the attached PDF rendering](https://github.com/input-output-hk/marlowe/files/9330519/specification-v3.pdf).
- [x] Introduction
- [x] Types
- [x] Semantics
- [x] Guarantees

There are several unsatisfactory aspects to the current draft: most of these relate to the fact that Isabelle's text-formatting system is designed for literate programming and apparently not for creating specification documents that excerpt definitions and proofs from other theory files. Specifically,
1. There is no antiquotation for record types.
2. There is no antiquotation for type synonym definitions.
3. Type synonyms are erased in `datatype` antiquotations.
4. Apparently, the Isabelle definitions of functions cannot be excerpted. (The present document falls back on Haskell code generation for this, but that is clearly unsatisfactory.)
5. Similarly for quoting excerpts of theorems, lemmas, or termination proofs.
This awkwardness is exacerbated by the fact that the *Guarantees* section of the document would need to quote an excessive number of functions, instances, theorems, and lemmas if it were to be self-contained. As it stands now, that section merely provides an overview and points the reader to entry points for the relevant proofs.

Given this unsatisfactory state of affairs, the following would be more optimal.
1. Convert the `Core/*.thy` files to fully-documented literate programs.
    * This will require much splitting and reorganizing, so (a) types, (b) semantics functions, and (c) minor functions, instances, lemmas, and theorems are in separate files..
    * A complete narrative of the proofs will be included (i.e., no hidden lemmas).
2. Migrate the existing narratives of the *Types*, *Semantics*, and *Guarantees* sections into those core theory files.

We could pursue this in the next version of this document, or do a major refactoring of the present version.

This documentation effort also revealed a few issues with definitions and proofs:
1.  `NumAccount` is unused. (Is there a linter we could run on the theories to detect problems like this?)
2. The type `Ada` is equated with `Money`, which is used to count *all* types of currency (not just Ada or, more properly, Lovelace). That Cardano-specific reference could be deleted.
3.  Perhaps we should separate the use of `TokenName` for roles versus for actual tokens, even though the Cardano implementation uses the same type for both.
4. Type synonyms and record types are awkward. Ideally, it would have been better for them all to be `datatype`, but it would involve too much reworking of the proofs to make that change in this version.
5. Are we missing a proof that all contracts close?

Finally, the introductory narrative is somewhat informal. Should we tighten it up and make it much more formal? or should we be more verbose and informal throughout the document?