### PR TITLE
SCP-4388 Replace PK for Address

### DIFF
--- a/isabelle/Core/SemanticsTypes.thy
+++ b/isabelle/Core/SemanticsTypes.thy
@@ -5,8 +5,6 @@ begin
 
 type_synonym POSIXTime = int
 
-type_synonym PubKey = ByteString
-
 type_synonym Ada = int
 type_synonym CurrencySymbol = ByteString
 type_synonym TokenName = ByteString
@@ -17,16 +15,16 @@ type_synonym Timeout = POSIXTime
 type_synonym Money = Ada
 type_synonym ChosenNum = int
 
-datatype Party = PubKey ByteString
+datatype Party = Address ByteString
                | Role TokenName
 
 type_synonym AccountId = Party
 
 (* BEGIN Proof of linorder for Party *)
 fun less_eq_Party :: "Party \<Rightarrow> Party \<Rightarrow> bool" where
-"less_eq_Party (PubKey _) (Role _) = True" |
-"less_eq_Party (Role _) (PubKey _) = False" |
-"less_eq_Party (PubKey x) (PubKey y) = less_eq_BS x y" |
+"less_eq_Party (Address _) (Role _) = True" |
+"less_eq_Party (Role _) (Address _) = False" |
+"less_eq_Party (Address x) (Address y) = less_eq_BS x y" |
 "less_eq_Party (Role x) (Role y) = less_eq_BS x y"
 
 fun less_Party :: "Party \<Rightarrow> Party \<Rightarrow> bool" where

--- a/isabelle/Doc/Specification/Core.thy
+++ b/isabelle/Doc/Specification/Core.thy
@@ -138,7 +138,7 @@ text \<open>A deposit input @{term "IDeposit a p t v"} exactly matches the actio
 subsection \<open>Party and Payee\label{sec:party}\<close>
 
 text \<open>A payment can be made to one of the parties to the contract, or to one of the accounts of the
-contract. A party may be identified by a public-key hash or by a role.
+contract. A party may be identified by an address or by a role.
 @{datatype [display,names_short, margin=40]Payee}
 @{datatype [display,names_short, margin=40]Party}
 \<close> text \<open>FIXME: print type synonym: @{term [names_short, margin=40]AccountId}
@@ -147,10 +147,9 @@ contract. A party may be identified by a public-key hash or by a role.
 text \<open>@{term "Account p"} identifies the internal account for party @{term p}, whereas
 @{term "Party p"} identifies the party itself.\<close>
 
-text \<open>@{term "PubKey h"} identifies a party by the hash @{term h} of a public key, whereas
+text \<open>@{term "Address addr"} identifies a party by a particular @{term addr} (which is Blockchain specific), whereas
 @{term "Role n"} identifies the party by the name @{term n} of their role.
-\<close> text \<open>FIXME: print type synonym: @{term [names_short, margin=40]PubKey}
-  \<close>
+\<close> 
 
 subsection \<open>Value\label{sec:value}\<close>
 

--- a/isabelle/Doc/Specification/Specification.thy
+++ b/isabelle/Doc/Specification/Specification.thy
@@ -87,22 +87,19 @@ Running a contract may also produce external effects, by making payments to part
 
 \<close>
 
-subsection \<open>Participants, roles, and public key\<close>
+subsection \<open>Participants, roles, and addresses\<close>
 
 text \<open>
 
-We should separate the notions of participant, role, and public keys in a Marlowe contract. A
-participant (or party) in the contract can be represented by either a role or a public key (public
-keys will eventually be replaced by addresses).
+We should separate the notions of participant, role, and addresses in a Marlowe contract. A
+participant (or party) in the contract can be represented by either a role or an address.
 
 Roles are represented by tokens and they are distributed to addresses at the time a contract is
 deployed to the blockchain. After that, whoever has the token representing a role is able to carry
 out the actions assigned to that role, and receive the payments that are issued to that role.
 
-Public key parties, are represented by the hash of a public key (or eventually an addresses). Using
-public keys to represent parties is simpler because it does not require handling tokens, but they
-cannot be traded, because once you know the private key for a given public key you cannot prove you
-have forgotten it.
+Address parties, are represented by a fixed address (the format is blockchain specific) and they are simpler,
+because it does not require handling tokens, but they cannot be traded.
 
 \<close>
 

--- a/src/Language/Marlowe/Semantics/Deserialisation.hs
+++ b/src/Language/Marlowe/Semantics/Deserialisation.hs
@@ -17,7 +17,7 @@ byteStringToParty x =
           Nothing -> Nothing
           Just (z, t2) ->
             ( if y == 0
-                then Just (PubKey z, t2)
+                then Just (Address z, t2)
                 else
                   ( if y == 1
                       then Just (Role z, t2)

--- a/src/Language/Marlowe/Semantics/Serialisation.hs
+++ b/src/Language/Marlowe/Semantics/Serialisation.hs
@@ -8,7 +8,7 @@ import           Language.Marlowe.Semantics.Types (Action (..), Bound (Bound), C
 import           Language.Marlowe.Serialisation (intToByteString, listToByteString, packByteString, positiveIntToByteString)
 
 partyToByteString :: Party -> ExtendedBuilder
-partyToByteString (PubKey x) = positiveIntToByteString 0 <> packByteString (ExtendedBuilder.byteString x)
+partyToByteString (Address x) = positiveIntToByteString 0 <> packByteString (ExtendedBuilder.byteString x)
 partyToByteString (Role x) = positiveIntToByteString 1 <> packByteString (ExtendedBuilder.byteString x)
 
 choiceIdToByteString :: ChoiceId -> ExtendedBuilder

--- a/src/Language/Marlowe/Semantics/Types.hs
+++ b/src/Language/Marlowe/Semantics/Types.hs
@@ -30,7 +30,7 @@ instance Num POSIXTime where
     fromInteger = POSIXTime
     negate (POSIXTime l) = POSIXTime (negate l)
 
-data Party = PubKey ByteString
+data Party = Address ByteString
            | Role ByteString
   deriving (Eq,Ord,Show,Read,Generic,Pretty)
 


### PR DESCRIPTION
The PubKey hash Party constructor doesn't allow for staking keys, it is easier to use an opaque Address, which each blockchain can use with different schemas.