### PR TITLE
SCP-4526 - Write function to calculate bounds for time intervals given a contract

### DIFF
--- a/isabelle/CodeExports/CodeExports.thy
+++ b/isabelle/CodeExports/CodeExports.thy
@@ -65,7 +65,7 @@ export_code
   getOutcomes
   getSignatures
   maxTimeContract
-  calculateTimeInterval
+  calculateNonAmbiguousInterval
 
   \<comment> \<open> Export examples to be used as oracle specificaiton tests\<close>
   swapExample

--- a/isabelle/CodeExports/CodeExports.thy
+++ b/isabelle/CodeExports/CodeExports.thy
@@ -61,6 +61,12 @@ export_code
   playTrace
   computeTransaction
 
+   \<comment> \<open> Export utility functions\<close>
+  getOutcomes
+  getSignatures
+  maxTimeContract
+  calculateTimeInterval
+
   \<comment> \<open> Export examples to be used as oracle specificaiton tests\<close>
   swapExample
   happyPathTransactions

--- a/isabelle/Core/OptBoundTimeInterval.thy
+++ b/isabelle/Core/OptBoundTimeInterval.thy
@@ -1,0 +1,274 @@
+theory OptBoundTimeInterval
+  imports SemanticsTypes
+begin
+
+chapter "Time Interval"
+text
+\<open>
+A BEndpoint represents either an Unbounded (-\infty  or \infty) endpoint or a closed (inclusive) bounded
+endpoint.
+\<close>
+datatype BEndpoint =
+  Unbounded
+  | Bounded POSIXTime
+
+text
+\<open>
+An Optionally bounded TimeInterval, is a normal TimeInterval  that might be unbounded on the
+left or right.
+\<close>
+type_synonym OptBoundTimeInterval = "BEndpoint \<times> BEndpoint"
+
+text
+\<open>
+We can think of an \<^emph>\<open>OptBoundTimeInterval\<close> as sets with four possible options:
+\<^item> Totally unbound: (-\infty, \infty)
+\<^item> Left bound [low, \infty)
+\<^item> Right bound (-\infty, high]
+\<^item> Bound [low, high].
+\<close>
+fun bToSet :: "OptBoundTimeInterval => POSIXTime set" where
+   "bToSet (Unbounded, Unbounded)   = {x. True}"
+ | "bToSet (Bounded l, Unbounded)   = {l..}"
+ | "bToSet (Unbounded, Bounded r) = {..r}"
+ | "bToSet (Bounded l, Bounded r) = {l..r}"
+
+
+section "Interval intesection"
+
+text
+\<open>
+The interval intersection is achieved by calculating the maximum lower bound and the minimum
+higher bound, favouring Bounded to Unbounded endpoits.
+\<close>
+fun maxLow :: "BEndpoint \<Rightarrow> BEndpoint \<Rightarrow> BEndpoint" where
+  "maxLow Unbounded y = y"
+| "maxLow x Unbounded = x"
+| "maxLow (Bounded x) (Bounded y) = Bounded (max x y)"
+
+
+fun minHigh :: "BEndpoint \<Rightarrow> BEndpoint \<Rightarrow> BEndpoint" where
+  "minHigh Unbounded y = y"
+| "minHigh x Unbounded = x"
+| "minHigh (Bounded x) (Bounded y) = Bounded (min x y)"
+
+fun intersectInterval :: "OptBoundTimeInterval \<Rightarrow> OptBoundTimeInterval \<Rightarrow> OptBoundTimeInterval"
+where
+ "intersectInterval (low1, high1) (low2, high2)
+    = (maxLow low1 low2, minHigh high1 high2)"
+
+
+subsection "Associativity"
+text
+\<open>
+Every function related to Interval Intersection is associative
+\<close>
+
+lemma(*<*)maxLow_assoc [simp]:(*>*)
+ "maxLow (maxLow a b) c = maxLow a (maxLow b c)"
+(*<*)
+  apply (cases a)
+   apply simp
+  apply (cases b)
+   apply simp
+  apply (cases c)
+  by auto
+(*>*)
+
+lemma(*<*)minHigh_assoc [simp]:(*>*)
+ "minHigh (minHigh a b) c = minHigh a (minHigh b c)"
+(*<*)
+  apply (cases a)
+   apply simp
+    apply (cases b)
+   apply simp
+  apply (cases c)
+  by auto
+(*>*)
+
+interpretation semigroup "intersectInterval"
+(*<*)
+  apply (unfold_locales)
+  subgoal for a b c
+    by (metis OptBoundTimeInterval.intersectInterval.simps maxLow_assoc minHigh_assoc surj_pair)
+  done
+(*>*)
+
+subsection "Commutative"
+text
+\<open>
+Every function related to Interval Intersection is commutative
+\<close>
+
+lemma(*<*)maxLow_comm [simp]:(*>*)
+ "maxLow a b = maxLow b a"
+  (*<*)
+  apply (cases a)
+  apply (metis OptBoundTimeInterval.BEndpoint.exhaust OptBoundTimeInterval.maxLow.simps(1) OptBoundTimeInterval.maxLow.simps(2))
+   apply auto
+   apply (cases b)
+  by auto
+  (*>*)
+
+lemma(*<*)minHigh_comm [simp]:(*>*)
+ "minHigh a b = minHigh b a"
+  (*<*)
+  apply (cases a)
+  apply (metis OptBoundTimeInterval.BEndpoint.distinct(1) OptBoundTimeInterval.minHigh.elims)
+   apply auto
+   apply (cases b)
+  by auto
+  (*>*)
+
+interpretation abel_semigroup "intersectInterval"
+  (*<*)
+  apply unfold_locales
+  subgoal for a b
+    by (metis (no_types, opaque_lifting) OptBoundTimeInterval.intersectInterval.elims fst_conv maxLow_comm minHigh_comm snd_conv)
+  done
+  (*>*)
+
+
+subsection "intersectInterval is set intersection"
+text
+\<open>
+This section proves that the function \<^emph>\<open>intersectInterval\<close> behaves the same as set intersection. In order to
+prove that theorem we have the following lemmas
+\<close>
+lemma (*<*)belongsToSubBelongsToSet_low_1:(*>*)
+  "x \<in> bToSet (maxLow l1 l2, r) \<Longrightarrow> x \<in> bToSet (l1, r)"
+
+(*<*)
+  apply (cases l1)
+   apply auto
+   apply (metis BEndpoint.exhaust bToSet.simps(1) bToSet.simps(3) bToSet.simps(4) atLeastAtMost_iff atMost_iff mem_Collect_eq)
+  apply (cases l2)
+  apply auto
+  by (metis Lattices.linorder_class.max.bounded_iff BEndpoint.exhaust bToSet.simps(2) bToSet.simps(4) atLeastAtMost_iff atLeast_iff)
+(*>*)
+
+lemma (*<*)belongsToSubBelongsToSet_low_2:(*>*)
+  "x \<in> bToSet (maxLow l1 l2, r) \<Longrightarrow> x \<in> bToSet (l2, r)"
+
+(*<*)
+  apply (cases l1)
+  by auto (smt (verit, best) BEndpoint.exhaust maxLow.simps(1) maxLow.simps(3) belongsToSubBelongsToSet_low_1)
+(*>*)
+
+lemma (*<*)belongsToSubBelongsToSet_high_1:(*>*)
+  "x \<in> bToSet (l, minHigh r1 r2) \<Longrightarrow> x \<in> bToSet (l, r1)"
+
+(*<*)
+  apply (induction r1 arbitrary: l)
+   apply auto
+     apply (cases r2)
+    apply auto
+   apply (metis BEndpoint.exhaust bToSet.simps(1) bToSet.simps(2) bToSet.simps(4) UNIV_I UNIV_def atLeastAtMost_iff atLeast_iff)
+  by (smt (verit, best) BEndpoint.distinct(1) BEndpoint.inject minHigh.elims bToSet.elims Pair_inject atLeastAtMost_iff atMost_iff)
+(*>*)
+
+lemma (*<*)belongsToSubBelongsToSet_high_2:(*>*)
+  "x \<in> bToSet (l, minHigh r1 r2) \<Longrightarrow> x \<in> bToSet (l, r2)"
+
+(*<*)
+  apply (cases r1)
+   apply auto
+  by (smt (verit, best) BEndpoint.exhaust minHigh.simps(1) minHigh.simps(3) belongsToSubBelongsToSet_high_1)
+(*>*)
+
+lemma (*<*)belongsToSubSet_BelongsToMaxLowSet [simp]:(*>*)
+  "x \<in> bToSet (l1, r) \<and> x \<in> bToSet (l2, r) \<Longrightarrow> x \<in> bToSet (maxLow l1 l2, r)"
+
+(*<*)
+  apply (cases l1)
+   apply auto
+  apply (cases l2)
+   apply auto
+  by linarith
+(*>*)
+
+lemma (*<*)belongsToSubSet_BelongsToMinHighSet [simp]:(*>*)
+  "x \<in> bToSet (l, r1) \<and> x \<in> bToSet (l, r2) \<Longrightarrow> x \<in> bToSet (l, minHigh r1 r2)"
+
+(*<*)
+  apply (cases r1)
+   apply auto
+  apply (cases r2)
+   apply auto
+  by linarith
+(*>*)
+
+lemma (*<*)belongsToSubSet_BelongsToSet:(*>*)
+"x \<in> bToSet (l1, r1) \<and> x \<in> bToSet (l2, r2) \<Longrightarrow> x \<in> bToSet (maxLow l1 l2, minHigh r1 r2)"
+
+(*<*)
+  apply (induction l1 arbitrary: r1)
+   apply (auto)
+   apply (metis BEndpoint.exhaust minHigh.simps(1) bToSet.simps(2) bToSet.simps(3) bToSet.simps(4) belongsToSubBelongsToSet_high_1 atLeastAtMost_iff atLeast_iff atMost_iff belongsToSubSet_BelongsToMinHighSet)
+  apply (induction l2 arbitrary: r2)
+   apply auto
+  apply (metis BEndpoint.exhaust bToSet.simps(2) bToSet.simps(3) bToSet.simps(4) atLeastAtMost_iff atLeast_iff atMost_iff belongsToSubSet_BelongsToMinHighSet)
+  by (metis Lattices.linorder_class.max.absorb_iff2 Lattices.linorder_class.max.commute BEndpoint.exhaust bToSet.simps(2) bToSet.simps(4) atLeastAtMost_iff atLeast_iff belongsToSubSet_BelongsToMinHighSet nle_le)
+(*>*)
+
+theorem (*<*)intersectIntervalIsIntersect:(*>*)
+"bToSet (intersectInterval a b) = bToSet a \<inter> bToSet b"
+
+(*<*)
+  apply (cases a)
+    apply (cases b)
+  apply auto
+  using belongsToSubBelongsToSet_low_1 belongsToSubBelongsToSet_high_1 apply blast
+  using belongsToSubBelongsToSet_low_2 belongsToSubBelongsToSet_high_2 apply blast
+  using belongsToSubSet_BelongsToSet by presburger
+(*>*)
+
+
+section "In Interval"
+
+
+text \<open>
+The inInterval function checks if a closed and bounded Time Interval is inside 
+an optional bounded closed time interval  
+\<close>
+fun inInterval :: "TimeInterval \<Rightarrow> OptBoundTimeInterval \<Rightarrow> bool" where
+"inInterval (min1, max1) (Unbounded, Unbounded) = True" |
+"inInterval (_, max1) (Unbounded, Bounded max2) = (max1 \<le> max2)" |
+"inInterval (min1, _) (Bounded min2, Unbounded) = (min1 \<ge> min2)" |
+"inInterval (min1, max1) (Bounded min2, Bounded max2) = (min1 \<ge> min2 \<and> max1 \<le> max2)"
+
+text 
+\<open>
+We can think of a TimeInterval as the set of times included by the boundaries
+\<close>
+fun tToSet :: "TimeInterval \<Rightarrow> POSIXTime set" where
+  "tToSet (l, r) = {l..r}"
+
+
+subsubsection "In interval implies a subset"
+
+text 
+\<open>
+A Time Interval is valid only if the left bound is lower or equal than the higher bound.
+\<close>
+
+fun validTimeInterval :: "TimeInterval \<Rightarrow> bool" where 
+  "validTimeInterval (l, r) = (l \<le> r)"
+
+
+text 
+\<open>
+If the Time Interval is valid, then the \<^emph>\<open>inInterval\<close> function implies a subset.
+\<close>
+theorem inInterval_subset: 
+  "validTimeInterval a \<Longrightarrow> inInterval a b = (tToSet a \<subseteq> bToSet b)"
+
+(*<*)
+  apply (cases a)
+  apply (cases b)
+  apply auto
+  using OptBoundTimeInterval.inInterval.elims(2) apply fastforce
+  using OptBoundTimeInterval.inInterval.elims(3) by fastforce
+(*>*)
+
+end

--- a/isabelle/Core/Semantics.thy
+++ b/isabelle/Core/Semantics.thy
@@ -723,6 +723,10 @@ fun gtIfNone :: "int option \<Rightarrow> int \<Rightarrow> bool" where
 "gtIfNone None _ = True" |
 "gtIfNone (Some x) y = (x > y)"
 
+fun geIfNone :: "int option \<Rightarrow> int \<Rightarrow> bool" where
+"geIfNone None _ = True" |
+"geIfNone (Some x) y = (x \<ge> y)"
+
 fun subIfSome :: "int option \<Rightarrow> int \<Rightarrow> int option" where
 "subIfSome None _ = None" |
 "subIfSome (Some x) y = Some (x - y)"

--- a/isabelle/Core/Semantics.thy
+++ b/isabelle/Core/Semantics.thy
@@ -706,4 +706,43 @@ and maxTimeCase :: "Case \<Rightarrow> int" where
 "maxTimeContract (Assert _ contract) = maxTimeContract contract" |
 "maxTimeCase (Case _ contract) = maxTimeContract contract"
 
+fun minOpt :: "POSIXTime option => POSIXTime option => POSIXTime option" where
+"minOpt None y = y" |
+"minOpt x None = x" |
+"minOpt (Some x) (Some y) = (Some (min x y))"
+
+fun maxOpt :: "POSIXTime option => POSIXTime option => POSIXTime option" where
+"maxOpt None y = y" |
+"maxOpt x None = x" |
+"maxOpt (Some x) (Some y) = (Some (max x y))"
+
+fun combineIntervals :: "POSIXTime option \<times> POSIXTime option \<Rightarrow> POSIXTime option \<times> POSIXTime option \<Rightarrow> POSIXTime option \<times> POSIXTime option" where
+"combineIntervals (min1, max1) (min2, max2) = (maxOpt min1 min2, minOpt max1 max2)"
+
+fun gtIfNone :: "int option \<Rightarrow> int \<Rightarrow> bool" where
+"gtIfNone None _ = True" |
+"gtIfNone (Some x) y = (x > y)"
+
+fun subIfSome :: "int option \<Rightarrow> int \<Rightarrow> int option" where
+"subIfSome None _ = None" |
+"subIfSome (Some x) y = Some (x - y)"
+
+fun calculateTimeInterval :: "int option \<Rightarrow> POSIXTime \<Rightarrow> Contract \<Rightarrow> POSIXTime option \<times> POSIXTime option"
+where
+"calculateTimeInterval _ _ Close = (None, None)" |
+"calculateTimeInterval n t (Pay _ _ _ _ c) = calculateTimeInterval n t c" |
+"calculateTimeInterval n t (If _ ct cf) = combineIntervals (calculateTimeInterval n t ct)
+                                                           (calculateTimeInterval n t cf)" |
+"calculateTimeInterval n t (When Nil timeout tcont) =
+  (if t < timeout
+   then (None, (Some (timeout - 1)))
+   else combineIntervals (Some timeout, None) (calculateTimeInterval n t tcont))" |
+"calculateTimeInterval n t (When (Cons (Case _ cont ) tail) timeout tcont) =
+  (if gtIfNone n 0
+   then combineIntervals (calculateTimeInterval (subIfSome n 1) t cont)
+                         (calculateTimeInterval n t (When tail timeout tcont))
+   else calculateTimeInterval n t (When tail timeout tcont))" |
+"calculateTimeInterval n t (Let _ _ c) = calculateTimeInterval n t c" |
+"calculateTimeInterval n t (Assert _ c) = calculateTimeInterval n t c"
+
 end

--- a/isabelle/Core/TimeRange.thy
+++ b/isabelle/Core/TimeRange.thy
@@ -1,0 +1,368 @@
+theory TimeRange
+imports Semantics PositiveAccounts QuiescentResult MoneyPreservation Timeout TransactionBound
+begin
+
+fun isCompatible :: "POSIXTime \<times> POSIXTime \<Rightarrow> POSIXTime option \<times> POSIXTime option \<Rightarrow> bool" where
+"isCompatible (min1, max1) (None, None) = True" |
+"isCompatible (_, max1) (None, Some max2) = (max1 \<le> max2)" |
+"isCompatible (min1, _) (Some min2, None) = (min1 \<ge> min2)" |
+"isCompatible (min1, max1) (Some min2, Some max2) = (min1 \<ge> min2 \<and> max1 \<le> max2)"
+
+theorem isCompatibleIdempotentToCombineInterval :
+  "isCompatible (min1, max1) (min2, max2) =
+     (combineIntervals (Some min1, Some max1) (min2, max2) = (Some min1, Some max1))"
+  apply (cases min2)
+  apply (cases max2)
+    apply simp
+  subgoal for a
+    by auto[1]
+    apply (cases max2)
+    subgoal for a
+      by auto
+    subgoal for a b
+      by auto
+    done
+
+lemma compatibleIdempotency1 :
+  "isCompatible (x, y) (combineIntervals b c) \<Longrightarrow> isCompatible (x, y) b"
+  apply (cases b)
+  apply (cases c)
+  subgoal for b1 b2 c1 c2
+    apply (simp only:combineIntervals.simps)
+    apply (cases b1)
+    apply (cases c1)
+    apply (smt (verit, best) Semantics.maxOpt.simps(1) Semantics.minOpt.elims TimeRange.isCompatible.simps(1) TimeRange.isCompatible.simps(2))
+    apply (smt (verit, ccfv_threshold) Semantics.minOpt.elims TimeRange.isCompatible.simps(1) TimeRange.isCompatible.simps(2) TimeRange.isCompatible.simps(4))
+    apply (cases c1)
+    apply simp
+    apply (smt (verit, del_insts) Option.option.sel Semantics.minOpt.elims TimeRange.isCompatible.simps(3) TimeRange.isCompatible.simps(4))
+    apply simp
+    apply (cases b2)
+    using isCompatibleIdempotentToCombineInterval apply force
+    apply (cases c2)
+     apply force
+    by simp
+  done
+
+lemma compatibleIdempotency2 :
+  "isCompatible (x, y) (combineIntervals b c) \<Longrightarrow> isCompatible (x, y) c"
+  apply (cases b)
+  apply (cases c)
+  subgoal for b1 b2 c1 c2
+    apply (simp only:combineIntervals.simps)
+    apply (cases b1)
+    apply (cases c1)
+    apply (smt (verit, ccfv_SIG) Semantics.maxOpt.simps(1) Semantics.minOpt.elims TimeRange.isCompatible.simps(1) TimeRange.isCompatible.simps(2))
+    apply simp
+    apply (smt (verit, best) Semantics.minOpt.elims TimeRange.isCompatible.simps(3) TimeRange.isCompatible.simps(4))
+    apply (cases c1)
+    apply simp
+    apply (smt (verit, best) Option.option.discI Pair_inject Semantics.minOpt.elims TimeRange.isCompatible.elims(1) TimeRange.isCompatible.simps(4))
+    apply simp
+    apply (cases b2)
+    using isCompatibleIdempotentToCombineInterval apply force
+    apply (cases c2)
+     apply force
+    by simp
+  done
+
+lemma compatibleIdempotencyWhen :
+  "b \<le> a2 \<Longrightarrow> b \<le> a1 \<Longrightarrow>
+   isCompatible (a1, a2) (calculateTimeInterval n ct (When a b c)) \<Longrightarrow>
+   isCompatible (a1, a2) (calculateTimeInterval n ct c)"
+  apply (induction a)
+  apply (smt (verit, best) Semantics.calculateTimeInterval.simps(4) TimeRange.isCompatible.simps(2) compatibleIdempotency2)
+  subgoal for c1 c2
+    apply (cases c1)
+    apply simp
+    apply (cases "gtIfNone n 0")
+     apply simp
+    using compatibleIdempotency2 apply blast
+    by presburger
+  done
+
+lemma calculateTimeIntervalAvoidsAmbiguousInterval_When :
+   "isCompatible (x, y) (calculateTimeInterval n ct (When a b c)) \<Longrightarrow>
+    y < b \<or> x \<ge> b"
+  apply (induction a arbitrary:x y n ct b c)
+  subgoal for x y n ct b c
+    apply (cases "ct < b")
+     apply simp
+    apply auto
+    using TimeRange.isCompatible.simps(3) compatibleIdempotency1 by blast
+  subgoal for a1 a2 x y n ct b c
+    apply (cases a1)
+    apply (simp only:calculateTimeInterval.simps)
+    subgoal for a ac
+      apply (cases "gtIfNone n 0")
+       apply simp
+      using compatibleIdempotency2 apply blast
+      by simp
+    done
+  done
+
+lemma calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractStep :
+"isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+ reduceContractStep env state contract \<noteq> AmbiguousTimeIntervalReductionError"
+  apply (cases contract)
+  apply (cases "refundOne (accounts state)")
+  apply auto[1]
+       apply auto[1]
+  subgoal for a b c d e
+    by (auto split:bool.splits simp add:Let_def)
+     apply simp
+  subgoal for a b c
+    apply (auto split:prod.splits)
+    subgoal for x y
+      using calculateTimeIntervalAvoidsAmbiguousInterval_When by blast
+    done
+  apply (simp add:Let_def)
+  by simp
+
+lemma resultOfReduceIsCompatibleToo :
+  "isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+   reduceContractStep env state contract = Reduced x11 x12 x13 x14 \<Longrightarrow>
+   isCompatible (timeInterval env) (calculateTimeInterval n ct x14)"
+  apply (cases contract)
+  using reduceStepClose_is_Close apply blast
+  subgoal for a b c d e
+    apply (cases "evalValue env state d \<le> 0")
+    by (simp_all add:Let_def)
+     apply (smt (verit, best) Semantics.ReduceStepResult.inject Semantics.calculateTimeInterval.simps(3) Semantics.reduceContractStep.simps(3) TimeRange.isCompatible.elims(2) compatibleIdempotency1 compatibleIdempotency2)
+  subgoal for a b c
+    apply (cases "timeInterval env")
+    apply (simp only:reduceContractStep.simps Let_def prod.case)
+    subgoal for a1 a2
+      apply (cases "a2 < b")
+       apply simp
+      apply simp
+      apply (cases "b \<le> a1")
+       apply simp
+       apply (meson compatibleIdempotencyWhen linorder_not_le)
+      by simp
+    done
+  apply (metis Semantics.ReduceStepResult.inject Semantics.calculateTimeInterval.simps(6) Semantics.reduceContractStep.simps(5))
+  by simp
+
+
+lemma resultOfReductionLoopQuiescentIsCompatibleToo :
+  "isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+   reductionLoop b env state contract wa ef = ContractQuiescent x11 x12 x13 x14 x15 \<Longrightarrow>
+   isCompatible (timeInterval env) (calculateTimeInterval n ct x15)"
+  apply (induction b env state contract wa ef rule:reductionLoop.induct)
+  subgoal for reduced env state contract warnings payments
+    apply (simp only:reductionLoop.simps[of reduced env state contract warnings payments])
+    apply (cases "reduceContractStep env state contract")
+    subgoal for warning effect newState ncontract
+      apply (simp only:Let_def ReduceStepResult.case)
+      using resultOfReduceIsCompatibleToo by presburger
+     apply force
+    by simp
+  done
+
+lemma resultOfReduceUntilQuiescentIsCompatibleToo :
+  "isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+   reduceContractUntilQuiescent env state contract = ContractQuiescent x11 x12 x13 x14 x15 \<Longrightarrow>
+   isCompatible (timeInterval env) (calculateTimeInterval n ct x15)"
+  by (metis Semantics.reduceContractUntilQuiescent.simps resultOfReductionLoopQuiescentIsCompatibleToo)
+
+lemma calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractUntilQuiescent :
+"isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+ reductionLoop b env state contract wa err \<noteq> RRAmbiguousTimeIntervalError"
+  apply (induction b env state contract wa err rule:reductionLoop.induct)
+  subgoal for reduced env state contract warnings payments
+    apply (simp only:reductionLoop.simps[of reduced env state contract warnings payments])
+    apply (cases "reduceContractStep env state contract")
+      apply (simp only:ReduceStepResult.case Let_def)
+    using resultOfReduceIsCompatibleToo apply presburger
+     apply simp
+    using calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractStep by auto
+  done
+
+fun childCase :: "Contract \<Rightarrow> Case list \<Rightarrow> bool" where
+"childCase c Nil = False" |
+"childCase c (Cons (Case _ h) t) = ((h = c) \<or> childCase c t)"
+
+lemma successInApplyCasesReturnChildCase :
+"applyCases env sta h l = Applied nwa nsta ncont \<Longrightarrow> childCase ncont l"
+  apply (induction l)
+   apply simp
+  subgoal for f t
+    apply (cases h)
+      apply (cases f)
+    subgoal for x11 x12 x13 x14 x1 x2
+      apply (cases x1)
+      apply (meson Semantics.ApplyResult.inject)
+        apply (metis Semantics.ApplyResult.inject Semantics.applyCases.simps(1) TimeRange.childCase.simps(2))
+       apply simp
+      by simp
+    apply (cases f)
+    subgoal for x21 x22 x1 x2
+      apply (cases x1)
+        apply simp
+       apply (metis Semantics.ApplyResult.inject Semantics.applyCases.simps(2) TimeRange.childCase.simps(2))
+      by simp
+    apply (cases f)
+    subgoal for x1 x2
+      apply (cases x1)
+    apply simp
+    apply simp
+      by (metis Semantics.ApplyResult.inject Semantics.applyCases.simps(3) TimeRange.childCase.simps(2))
+    done
+  done
+
+lemma resultOfApplyCaseIsCompatibleToo_aux :
+"isCompatible (timeInterval env) (calculateTimeInterval n ct (When x41 x42 x43)) \<Longrightarrow>
+ childCase ncont x41 \<Longrightarrow> ct < x42 \<Longrightarrow> gtIfNone n 0 \<Longrightarrow>
+ isCompatible (timeInterval env) (calculateTimeInterval (subIfSome n 1) ct ncont)"
+  apply (induction x41)
+   apply simp
+  subgoal for h t
+    apply (cases h)
+    subgoal for x y
+      apply simp
+    by (smt (verit, best) TimeRange.isCompatible.elims(3) compatibleIdempotency1 compatibleIdempotency2)
+  done
+  done
+
+lemma resultOfApplyCaseIsCompatibleToo :
+"isCompatible (timeInterval env) (calculateTimeInterval n ct (When x41 x42 x43)) \<Longrightarrow>
+ applyCases env sta h x41 = Applied nwa nsta ncont \<Longrightarrow> ct < x42 \<Longrightarrow> gtIfNone n 0 \<Longrightarrow>
+ isCompatible (timeInterval env) (calculateTimeInterval (subIfSome n 1) ct ncont)"
+  by (simp add: resultOfApplyCaseIsCompatibleToo_aux successInApplyCasesReturnChildCase)
+
+fun ifCaseLt :: "POSIXTime \<Rightarrow> Contract \<Rightarrow> bool" where
+"ifCaseLt ct (When a b c) = (ct < b)" |
+"ifCaseLt _ _ = True"
+
+lemma resultOfApplyInputIsCompatibleToo :
+"isCompatible (timeInterval env) (calculateTimeInterval n ct cont) \<Longrightarrow>
+ applyInput env sta h cont = Applied nwa nsta ncont \<Longrightarrow> ifCaseLt ct cont \<Longrightarrow> gtIfNone n 0 \<Longrightarrow>
+ isCompatible (timeInterval env) (calculateTimeInterval (subIfSome n 1) ct ncont)"
+  apply (cases cont)
+  apply simp_all
+  by (simp add: resultOfApplyCaseIsCompatibleToo)
+
+lemma geIfNone_redListSize :
+  "geIfNone n (int (length (h # t))) \<Longrightarrow> geIfNone (subIfSome n 1) (int (length t))"
+  by (smt (verit, ccfv_threshold) Semantics.geIfNone.elims(1) Semantics.geIfNone.simps(2) Semantics.subIfSome.elims impossible_Cons of_nat_le_iff)
+
+fun isValidInterval :: "POSIXTime \<times> POSIXTime \<Rightarrow> bool" where
+"isValidInterval (a, b) = (a \<le> b)"
+
+lemma reduceStep_ifCaseLtCt_aux : "isCompatible (a, b) (calculateTimeInterval n ct (When x41 x42 x43)) \<Longrightarrow>
+                                   a \<le> b \<Longrightarrow> env = \<lparr>timeInterval = (a, b)\<rparr> \<Longrightarrow> b < x42 \<Longrightarrow> ct < x42"
+  apply (induction x41)
+   apply simp
+   apply (smt (verit, best) TimeRange.isCompatible.simps(3) compatibleIdempotency1)
+  subgoal for h t
+    apply simp
+    apply (cases h)
+    apply simp
+  using compatibleIdempotency2 by presburger
+  done
+
+lemma reduceStep_ifCaseLtCt : "isCompatible (timeInterval env) (calculateTimeInterval n ct (When x41 x42 x43)) \<Longrightarrow> 
+                               reduceContractStep env state (When x41 x42 x43) = NotReduced \<Longrightarrow> isValidInterval (timeInterval env) \<Longrightarrow> ct < x42"
+  apply (cases env)
+  subgoal for timeInterv
+    apply (cases timeInterv)
+    apply simp
+    subgoal for a b
+      apply (cases "b < x42")
+       apply simp
+      using reduceStep_ifCaseLtCt_aux apply blast
+      by (metis Semantics.ReduceStepResult.distinct(5) Semantics.ReduceStepResult.simps(3))
+    done
+  done
+
+
+lemma reduceLoop_ifCaseLtCt : "isCompatible (timeInterval env) (calculateTimeInterval n ct cont) \<Longrightarrow>
+                               reductionLoop b env state cont wa ef = ContractQuiescent x11 x12 x13 x14 x15 \<Longrightarrow> isValidInterval (timeInterval env) \<Longrightarrow> ifCaseLt ct x15"
+  apply (induction b env state cont wa ef rule:reductionLoop.induct)
+  subgoal for reduced env state contract warnings payments
+  apply (cases "x15 = Close")
+  apply simp
+  apply (cases x15)
+  apply simp
+  apply simp
+  apply simp
+    apply (simp only:reductionLoop.simps[of reduced env state contract warnings payments])
+    apply (cases "reduceContractStep env state contract")
+    apply (simp only:ReduceStepResult.case)
+    using resultOfReduceIsCompatibleToo apply presburger
+    apply (simp only:ReduceStepResult.case ifCaseLt.simps)
+       apply (simp add: reduceStep_ifCaseLtCt)
+    apply force
+    using TimeRange.ifCaseLt.simps(5) apply blast
+    using TimeRange.ifCaseLt.simps(6) by blast
+  done
+
+lemma reduceContractUntilQuiescent_ifCaseLtCt : "isCompatible (timeInterval env) (calculateTimeInterval n ct cont) \<Longrightarrow>
+                                                 reduceContractUntilQuiescent env state cont = ContractQuiescent x11 x12 x13 x14 x15 \<Longrightarrow>
+                                                 isValidInterval (timeInterval env) \<Longrightarrow> ifCaseLt ct x15"
+  apply (simp only:reduceContractUntilQuiescent.simps)
+  by (simp add: reduceLoop_ifCaseLtCt)
+
+lemma calculateTimeIntervalAvoidsAmbiguousInterval_applyAllLoop :
+"geIfNone n (int (length inps)) \<Longrightarrow>
+ isCompatible (timeInterval env) (calculateTimeInterval n ct c) \<Longrightarrow>
+ isValidInterval (timeInterval env) \<Longrightarrow> 
+ applyAllLoop b env s c inps wa ef \<noteq>
+ ApplyAllAmbiguousTimeIntervalError"
+  apply (induction b env s c inps wa ef arbitrary: n ct rule:applyAllLoop.induct)
+  subgoal for contractChanged env state contract inputs warnings payments n ct
+    apply (simp only:applyAllLoop.simps[of contractChanged env state contract inputs warnings payments])
+    apply (cases "reduceContractUntilQuiescent env state contract")
+     apply (simp only:ReduceResult.case)
+    apply (cases inputs)
+    apply (simp only:list.cases)
+      apply force
+     apply (simp only:list.cases)
+    subgoal for x11 x12 x13 x14 x15 h t
+      apply (cases "applyInput env x14 h x15")
+       apply (simp only:ApplyResult.case)
+      subgoal fact for nwa nsta ncont
+        subgoal premises fact
+        apply (rule fact(1)[of x11 x12 x13 x14 x15 h t nwa nsta ncont "subIfSome n 1" "ct"])
+            apply auto
+            apply (simp add: fact(7))
+            using fact(2) geIfNone_redListSize apply auto[1]
+            apply (rule resultOfApplyInputIsCompatibleToo[of env n ct x15 x14 h nwa nsta])
+            using fact(3) fact(5) resultOfReduceUntilQuiescentIsCompatibleToo apply blast
+            apply (simp add: fact(7))
+            using fact(3) fact(4) fact(5) reduceContractUntilQuiescent_ifCaseLtCt apply blast
+            using Semantics.gtIfNone.elims(3) fact(2) of_nat_le_iff by fastforce
+          done
+        by (metis Semantics.ApplyAllResult.distinct(5) Semantics.ApplyResult.simps(5))
+      using calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractUntilQuiescent by auto
+    done
+
+lemma calculateTimeIntervalAvoidsAmbiguousInterval_applyAllInputs :
+"geIfNone n (int (length inps)) \<Longrightarrow>
+ isCompatible (minInterv, maxInterv) (calculateTimeInterval n ct c) \<Longrightarrow>
+ isValidInterval (minInterv, maxInterv) \<Longrightarrow> 
+ applyAllInputs \<lparr> timeInterval = (minInterv, maxInterv) \<rparr> s c inps
+    \<noteq> ApplyAllAmbiguousTimeIntervalError"
+  apply (simp only:applyAllInputs.simps)
+  using calculateTimeIntervalAvoidsAmbiguousInterval_applyAllLoop by auto
+
+theorem calculateTimeIntervalAvoidsAmbiguousInterval :
+  "geIfNone n (int (length (inputs tx))) \<Longrightarrow>
+   isCompatible (interval tx) (calculateTimeInterval n ct c) \<Longrightarrow>
+   computeTransaction tx s c \<noteq> TransactionError TEAmbiguousTimeIntervalError"
+  apply (simp only:computeTransaction.simps Let_def)
+  apply (cases tx)
+  subgoal for interv inps
+    apply (cases interv)
+    subgoal for minInterv maxInterv
+      apply (simp add:Let_def del:applyAllInputs.simps)
+      apply (cases "applyAllInputs \<lparr>timeInterval = (max minInterv (minTime s), maxInterv)\<rparr>
+           (s\<lparr>minTime := max minInterv (minTime s)\<rparr>) c inps")
+      apply simp
+      apply simp
+      apply (simp del:applyAllInputs.simps)
+      by (smt (verit) Semantics.applyAllInputs.simps SemanticsTypes.Environment.select_convs(1) TimeRange.isCompatible.elims(2) TimeRange.isCompatible.simps(1) TimeRange.isCompatible.simps(2) TimeRange.isCompatible.simps(3) TimeRange.isCompatible.simps(4) TimeRange.isValidInterval.simps calculateTimeIntervalAvoidsAmbiguousInterval_applyAllLoop)
+    done
+  done
+end

--- a/isabelle/Core/TimeRange.thy
+++ b/isabelle/Core/TimeRange.thy
@@ -2,15 +2,9 @@ theory TimeRange
 imports Semantics PositiveAccounts QuiescentResult MoneyPreservation Timeout TransactionBound
 begin
 
-fun isCompatible :: "POSIXTime \<times> POSIXTime \<Rightarrow> POSIXTime option \<times> POSIXTime option \<Rightarrow> bool" where
-"isCompatible (min1, max1) (None, None) = True" |
-"isCompatible (_, max1) (None, Some max2) = (max1 \<le> max2)" |
-"isCompatible (min1, _) (Some min2, None) = (min1 \<ge> min2)" |
-"isCompatible (min1, max1) (Some min2, Some max2) = (min1 \<ge> min2 \<and> max1 \<le> max2)"
-
-theorem isCompatibleIdempotentToCombineInterval :
-  "isCompatible (min1, max1) (min2, max2) =
-     (combineIntervals (Some min1, Some max1) (min2, max2) = (Some min1, Some max1))"
+theorem inIntervalIdempotentToIntersectInterval :
+  "inInterval (min1, max1) (min2, max2) =
+     (intersectInterval (Bounded min1, Bounded max1) (min2, max2) = (Bounded min1, Bounded max1))"
   apply (cases min2)
   apply (cases max2)
     apply simp
@@ -23,86 +17,73 @@ theorem isCompatibleIdempotentToCombineInterval :
       by auto
     done
 
-lemma compatibleIdempotency1 :
-  "isCompatible (x, y) (combineIntervals b c) \<Longrightarrow> isCompatible (x, y) b"
+lemma inIntervalIdempotency1 :
+  "inInterval (x, y) (intersectInterval b c) \<Longrightarrow> inInterval (x, y) b"
   apply (cases b)
   apply (cases c)
   subgoal for b1 b2 c1 c2
-    apply (simp only:combineIntervals.simps)
+    apply (simp only:inInterval.simps)
     apply (cases b1)
     apply (cases c1)
-    apply (smt (verit, best) Semantics.maxOpt.simps(1) Semantics.minOpt.elims TimeRange.isCompatible.simps(1) TimeRange.isCompatible.simps(2))
-    apply (smt (verit, ccfv_threshold) Semantics.minOpt.elims TimeRange.isCompatible.simps(1) TimeRange.isCompatible.simps(2) TimeRange.isCompatible.simps(4))
+    apply (smt (verit, best) OptBoundTimeInterval.intersectInterval.simps OptBoundTimeInterval.maxLow.simps(1) OptBoundTimeInterval.minHigh.elims assoc commute inIntervalIdempotentToIntersectInterval)
+    apply (smt (verit, ccfv_threshold) OptBoundTimeInterval.inInterval.simps(2) OptBoundTimeInterval.inInterval.simps(4) OptBoundTimeInterval.intersectInterval.simps OptBoundTimeInterval.maxLow.simps(2) OptBoundTimeInterval.minHigh.elims OptBoundTimeInterval.minHigh.simps(2) inIntervalIdempotentToIntersectInterval maxLow_comm)
     apply (cases c1)
     apply simp
-    apply (smt (verit, del_insts) Option.option.sel Semantics.minOpt.elims TimeRange.isCompatible.simps(3) TimeRange.isCompatible.simps(4))
-    apply simp
-    apply (cases b2)
-    using isCompatibleIdempotentToCombineInterval apply force
-    apply (cases c2)
-     apply force
-    by simp
+    apply (smt (verit, ccfv_threshold) OptBoundTimeInterval.inInterval.simps(3) OptBoundTimeInterval.inInterval.simps(4) OptBoundTimeInterval.minHigh.elims)
+    by (smt (verit) Groups.abel_semigroup.commute Groups.semigroup.assoc OptBoundTimeInterval.intersectInterval.simps OptBoundTimeInterval.maxLow.simps(3) OptBoundTimeInterval.minHigh.elims abel_semigroup_axioms inIntervalIdempotentToIntersectInterval semigroup_axioms)
   done
 
-lemma compatibleIdempotency2 :
-  "isCompatible (x, y) (combineIntervals b c) \<Longrightarrow> isCompatible (x, y) c"
+lemma inIntervalIdempotency2 :
+  "inInterval (x, y) (intersectInterval b c) \<Longrightarrow> inInterval (x, y) c"
   apply (cases b)
   apply (cases c)
   subgoal for b1 b2 c1 c2
-    apply (simp only:combineIntervals.simps)
+    apply (simp only:intersectInterval.simps)
     apply (cases b1)
     apply (cases c1)
-    apply (smt (verit, ccfv_SIG) Semantics.maxOpt.simps(1) Semantics.minOpt.elims TimeRange.isCompatible.simps(1) TimeRange.isCompatible.simps(2))
+    apply (metis OptBoundTimeInterval.intersectInterval.simps commute inIntervalIdempotency1)
+    apply (metis OptBoundTimeInterval.intersectInterval.simps commute inIntervalIdempotency1)
     apply simp
-    apply (smt (verit, best) Semantics.minOpt.elims TimeRange.isCompatible.simps(3) TimeRange.isCompatible.simps(4))
-    apply (cases c1)
-    apply simp
-    apply (smt (verit, best) Option.option.discI Pair_inject Semantics.minOpt.elims TimeRange.isCompatible.elims(1) TimeRange.isCompatible.simps(4))
-    apply simp
-    apply (cases b2)
-    using isCompatibleIdempotentToCombineInterval apply force
-    apply (cases c2)
-     apply force
-    by simp
+    by (metis OptBoundTimeInterval.intersectInterval.simps inIntervalIdempotency1 minHigh_comm)
   done
 
 lemma compatibleIdempotencyWhen :
   "b \<le> a2 \<Longrightarrow> b \<le> a1 \<Longrightarrow>
-   isCompatible (a1, a2) (calculateTimeInterval n ct (When a b c)) \<Longrightarrow>
-   isCompatible (a1, a2) (calculateTimeInterval n ct c)"
+   inInterval (a1, a2) (calculateNonAmbiguousInterval n ct (When a b c)) \<Longrightarrow>
+   inInterval (a1, a2) (calculateNonAmbiguousInterval n ct c)"
   apply (induction a)
-  apply (smt (verit, best) Semantics.calculateTimeInterval.simps(4) TimeRange.isCompatible.simps(2) compatibleIdempotency2)
+  apply (smt (verit, best) OptBoundTimeInterval.inInterval.simps(2) Semantics.calculateNonAmbiguousInterval.simps(4) inIntervalIdempotency2)
   subgoal for c1 c2
     apply (cases c1)
     apply simp
     apply (cases "gtIfNone n 0")
      apply simp
-    using compatibleIdempotency2 apply blast
+    using inIntervalIdempotency2 apply blast
     by presburger
   done
 
-lemma calculateTimeIntervalAvoidsAmbiguousInterval_When :
-   "isCompatible (x, y) (calculateTimeInterval n ct (When a b c)) \<Longrightarrow>
+lemma calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_When :
+   "inInterval (x, y) (calculateNonAmbiguousInterval n ct (When a b c)) \<Longrightarrow>
     y < b \<or> x \<ge> b"
   apply (induction a arbitrary:x y n ct b c)
   subgoal for x y n ct b c
     apply (cases "ct < b")
      apply simp
     apply auto
-    using TimeRange.isCompatible.simps(3) compatibleIdempotency1 by blast
+    using OptBoundTimeInterval.inInterval.simps(3) inIntervalIdempotency1 by blast
   subgoal for a1 a2 x y n ct b c
     apply (cases a1)
-    apply (simp only:calculateTimeInterval.simps)
+    apply (simp only:calculateNonAmbiguousInterval.simps)
     subgoal for a ac
       apply (cases "gtIfNone n 0")
        apply simp
-      using compatibleIdempotency2 apply blast
+      using inIntervalIdempotency2 apply blast
       by simp
     done
   done
 
-lemma calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractStep :
-"isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+lemma calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_reduceContractStep :
+"inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct contract) \<Longrightarrow>
  reduceContractStep env state contract \<noteq> AmbiguousTimeIntervalReductionError"
   apply (cases contract)
   apply (cases "refundOne (accounts state)")
@@ -114,21 +95,21 @@ lemma calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractStep :
   subgoal for a b c
     apply (auto split:prod.splits)
     subgoal for x y
-      using calculateTimeIntervalAvoidsAmbiguousInterval_When by blast
+      using calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_When by blast
     done
   apply (simp add:Let_def)
   by simp
 
 lemma resultOfReduceIsCompatibleToo :
-  "isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+  "inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct contract) \<Longrightarrow>
    reduceContractStep env state contract = Reduced x11 x12 x13 x14 \<Longrightarrow>
-   isCompatible (timeInterval env) (calculateTimeInterval n ct x14)"
+   inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct x14)"
   apply (cases contract)
   using reduceStepClose_is_Close apply blast
   subgoal for a b c d e
     apply (cases "evalValue env state d \<le> 0")
     by (simp_all add:Let_def)
-     apply (smt (verit, best) Semantics.ReduceStepResult.inject Semantics.calculateTimeInterval.simps(3) Semantics.reduceContractStep.simps(3) TimeRange.isCompatible.elims(2) compatibleIdempotency1 compatibleIdempotency2)
+    apply (smt (verit, del_insts) OptBoundTimeInterval.inInterval.elims(3) Semantics.ReduceStepResult.inject Semantics.calculateNonAmbiguousInterval.simps(3) Semantics.reduceContractStep.simps(3) inIntervalIdempotency1 inIntervalIdempotency2)
   subgoal for a b c
     apply (cases "timeInterval env")
     apply (simp only:reduceContractStep.simps Let_def prod.case)
@@ -141,14 +122,14 @@ lemma resultOfReduceIsCompatibleToo :
        apply (meson compatibleIdempotencyWhen linorder_not_le)
       by simp
     done
-  apply (metis Semantics.ReduceStepResult.inject Semantics.calculateTimeInterval.simps(6) Semantics.reduceContractStep.simps(5))
+  apply (metis Semantics.ReduceStepResult.inject Semantics.calculateNonAmbiguousInterval.simps(6) Semantics.reduceContractStep.simps(5))
   by simp
 
 
 lemma resultOfReductionLoopQuiescentIsCompatibleToo :
-  "isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+  "inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct contract) \<Longrightarrow>
    reductionLoop b env state contract wa ef = ContractQuiescent x11 x12 x13 x14 x15 \<Longrightarrow>
-   isCompatible (timeInterval env) (calculateTimeInterval n ct x15)"
+   inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct x15)"
   apply (induction b env state contract wa ef rule:reductionLoop.induct)
   subgoal for reduced env state contract warnings payments
     apply (simp only:reductionLoop.simps[of reduced env state contract warnings payments])
@@ -161,13 +142,13 @@ lemma resultOfReductionLoopQuiescentIsCompatibleToo :
   done
 
 lemma resultOfReduceUntilQuiescentIsCompatibleToo :
-  "isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+  "inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct contract) \<Longrightarrow>
    reduceContractUntilQuiescent env state contract = ContractQuiescent x11 x12 x13 x14 x15 \<Longrightarrow>
-   isCompatible (timeInterval env) (calculateTimeInterval n ct x15)"
+   inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct x15)"
   by (metis Semantics.reduceContractUntilQuiescent.simps resultOfReductionLoopQuiescentIsCompatibleToo)
 
-lemma calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractUntilQuiescent :
-"isCompatible (timeInterval env) (calculateTimeInterval n ct contract) \<Longrightarrow>
+lemma calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_reduceContractUntilQuiescent :
+"inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct contract) \<Longrightarrow>
  reductionLoop b env state contract wa err \<noteq> RRAmbiguousTimeIntervalError"
   apply (induction b env state contract wa err rule:reductionLoop.induct)
   subgoal for reduced env state contract warnings payments
@@ -176,7 +157,7 @@ lemma calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractUntilQuiescent 
       apply (simp only:ReduceStepResult.case Let_def)
     using resultOfReduceIsCompatibleToo apply presburger
      apply simp
-    using calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractStep by auto
+    using calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_reduceContractStep by auto
   done
 
 fun childCase :: "Contract \<Rightarrow> Case list \<Rightarrow> bool" where
@@ -212,23 +193,23 @@ lemma successInApplyCasesReturnChildCase :
   done
 
 lemma resultOfApplyCaseIsCompatibleToo_aux :
-"isCompatible (timeInterval env) (calculateTimeInterval n ct (When x41 x42 x43)) \<Longrightarrow>
+"inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct (When x41 x42 x43)) \<Longrightarrow>
  childCase ncont x41 \<Longrightarrow> ct < x42 \<Longrightarrow> gtIfNone n 0 \<Longrightarrow>
- isCompatible (timeInterval env) (calculateTimeInterval (subIfSome n 1) ct ncont)"
+ inInterval (timeInterval env) (calculateNonAmbiguousInterval (subIfSome n 1) ct ncont)"
   apply (induction x41)
    apply simp
   subgoal for h t
     apply (cases h)
     subgoal for x y
       apply simp
-    by (smt (verit, best) TimeRange.isCompatible.elims(3) compatibleIdempotency1 compatibleIdempotency2)
+      by (smt (verit, best) OptBoundTimeInterval.inInterval.elims(3) inIntervalIdempotency1 inIntervalIdempotency2)
   done
   done
 
 lemma resultOfApplyCaseIsCompatibleToo :
-"isCompatible (timeInterval env) (calculateTimeInterval n ct (When x41 x42 x43)) \<Longrightarrow>
+"inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct (When x41 x42 x43)) \<Longrightarrow>
  applyCases env sta h x41 = Applied nwa nsta ncont \<Longrightarrow> ct < x42 \<Longrightarrow> gtIfNone n 0 \<Longrightarrow>
- isCompatible (timeInterval env) (calculateTimeInterval (subIfSome n 1) ct ncont)"
+ inInterval (timeInterval env) (calculateNonAmbiguousInterval (subIfSome n 1) ct ncont)"
   by (simp add: resultOfApplyCaseIsCompatibleToo_aux successInApplyCasesReturnChildCase)
 
 fun ifCaseLt :: "POSIXTime \<Rightarrow> Contract \<Rightarrow> bool" where
@@ -236,9 +217,9 @@ fun ifCaseLt :: "POSIXTime \<Rightarrow> Contract \<Rightarrow> bool" where
 "ifCaseLt _ _ = True"
 
 lemma resultOfApplyInputIsCompatibleToo :
-"isCompatible (timeInterval env) (calculateTimeInterval n ct cont) \<Longrightarrow>
+"inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct cont) \<Longrightarrow>
  applyInput env sta h cont = Applied nwa nsta ncont \<Longrightarrow> ifCaseLt ct cont \<Longrightarrow> gtIfNone n 0 \<Longrightarrow>
- isCompatible (timeInterval env) (calculateTimeInterval (subIfSome n 1) ct ncont)"
+ inInterval (timeInterval env) (calculateNonAmbiguousInterval (subIfSome n 1) ct ncont)"
   apply (cases cont)
   apply simp_all
   by (simp add: resultOfApplyCaseIsCompatibleToo)
@@ -250,19 +231,19 @@ lemma geIfNone_redListSize :
 fun isValidInterval :: "POSIXTime \<times> POSIXTime \<Rightarrow> bool" where
 "isValidInterval (a, b) = (a \<le> b)"
 
-lemma reduceStep_ifCaseLtCt_aux : "isCompatible (a, b) (calculateTimeInterval n ct (When x41 x42 x43)) \<Longrightarrow>
+lemma reduceStep_ifCaseLtCt_aux : "inInterval (a, b) (calculateNonAmbiguousInterval n ct (When x41 x42 x43)) \<Longrightarrow>
                                    a \<le> b \<Longrightarrow> env = \<lparr>timeInterval = (a, b)\<rparr> \<Longrightarrow> b < x42 \<Longrightarrow> ct < x42"
   apply (induction x41)
    apply simp
-   apply (smt (verit, best) TimeRange.isCompatible.simps(3) compatibleIdempotency1)
+   apply (smt (verit, best) OptBoundTimeInterval.inInterval.simps(3) inIntervalIdempotency1)
   subgoal for h t
     apply simp
     apply (cases h)
     apply simp
-  using compatibleIdempotency2 by presburger
+  using inIntervalIdempotency2 by presburger
   done
 
-lemma reduceStep_ifCaseLtCt : "isCompatible (timeInterval env) (calculateTimeInterval n ct (When x41 x42 x43)) \<Longrightarrow> 
+lemma reduceStep_ifCaseLtCt : "inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct (When x41 x42 x43)) \<Longrightarrow>
                                reduceContractStep env state (When x41 x42 x43) = NotReduced \<Longrightarrow> isValidInterval (timeInterval env) \<Longrightarrow> ct < x42"
   apply (cases env)
   subgoal for timeInterv
@@ -277,7 +258,7 @@ lemma reduceStep_ifCaseLtCt : "isCompatible (timeInterval env) (calculateTimeInt
   done
 
 
-lemma reduceLoop_ifCaseLtCt : "isCompatible (timeInterval env) (calculateTimeInterval n ct cont) \<Longrightarrow>
+lemma reduceLoop_ifCaseLtCt : "inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct cont) \<Longrightarrow>
                                reductionLoop b env state cont wa ef = ContractQuiescent x11 x12 x13 x14 x15 \<Longrightarrow> isValidInterval (timeInterval env) \<Longrightarrow> ifCaseLt ct x15"
   apply (induction b env state cont wa ef rule:reductionLoop.induct)
   subgoal for reduced env state contract warnings payments
@@ -298,16 +279,16 @@ lemma reduceLoop_ifCaseLtCt : "isCompatible (timeInterval env) (calculateTimeInt
     using TimeRange.ifCaseLt.simps(6) by blast
   done
 
-lemma reduceContractUntilQuiescent_ifCaseLtCt : "isCompatible (timeInterval env) (calculateTimeInterval n ct cont) \<Longrightarrow>
+lemma reduceContractUntilQuiescent_ifCaseLtCt : "inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct cont) \<Longrightarrow>
                                                  reduceContractUntilQuiescent env state cont = ContractQuiescent x11 x12 x13 x14 x15 \<Longrightarrow>
                                                  isValidInterval (timeInterval env) \<Longrightarrow> ifCaseLt ct x15"
   apply (simp only:reduceContractUntilQuiescent.simps)
   by (simp add: reduceLoop_ifCaseLtCt)
 
-lemma calculateTimeIntervalAvoidsAmbiguousInterval_applyAllLoop :
+lemma calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_applyAllLoop :
 "geIfNone n (int (length inps)) \<Longrightarrow>
- isCompatible (timeInterval env) (calculateTimeInterval n ct c) \<Longrightarrow>
- isValidInterval (timeInterval env) \<Longrightarrow> 
+ inInterval (timeInterval env) (calculateNonAmbiguousInterval n ct c) \<Longrightarrow>
+ isValidInterval (timeInterval env) \<Longrightarrow>
  applyAllLoop b env s c inps wa ef \<noteq>
  ApplyAllAmbiguousTimeIntervalError"
   apply (induction b env s c inps wa ef arbitrary: n ct rule:applyAllLoop.induct)
@@ -335,21 +316,21 @@ lemma calculateTimeIntervalAvoidsAmbiguousInterval_applyAllLoop :
             using Semantics.gtIfNone.elims(3) fact(2) of_nat_le_iff by fastforce
           done
         by (metis Semantics.ApplyAllResult.distinct(5) Semantics.ApplyResult.simps(5))
-      using calculateTimeIntervalAvoidsAmbiguousInterval_reduceContractUntilQuiescent by auto
+      using calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_reduceContractUntilQuiescent by auto
     done
 
-lemma calculateTimeIntervalAvoidsAmbiguousInterval_applyAllInputs :
+lemma calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_applyAllInputs :
 "geIfNone n (int (length inps)) \<Longrightarrow>
- isCompatible (minInterv, maxInterv) (calculateTimeInterval n ct c) \<Longrightarrow>
- isValidInterval (minInterv, maxInterv) \<Longrightarrow> 
+ inInterval (minInterv, maxInterv) (calculateNonAmbiguousInterval n ct c) \<Longrightarrow>
+ isValidInterval (minInterv, maxInterv) \<Longrightarrow>
  applyAllInputs \<lparr> timeInterval = (minInterv, maxInterv) \<rparr> s c inps
     \<noteq> ApplyAllAmbiguousTimeIntervalError"
   apply (simp only:applyAllInputs.simps)
-  using calculateTimeIntervalAvoidsAmbiguousInterval_applyAllLoop by auto
+  using calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_applyAllLoop by auto
 
-theorem calculateTimeIntervalAvoidsAmbiguousInterval :
+theorem calculateNonAmbiguousIntervalAvoidsAmbiguousInterval :
   "geIfNone n (int (length (inputs tx))) \<Longrightarrow>
-   isCompatible (interval tx) (calculateTimeInterval n ct c) \<Longrightarrow>
+   inInterval (interval tx) (calculateNonAmbiguousInterval n ct c) \<Longrightarrow>
    computeTransaction tx s c \<noteq> TransactionError TEAmbiguousTimeIntervalError"
   apply (simp only:computeTransaction.simps Let_def)
   apply (cases tx)
@@ -360,9 +341,28 @@ theorem calculateTimeIntervalAvoidsAmbiguousInterval :
       apply (cases "applyAllInputs \<lparr>timeInterval = (max minInterv (minTime s), maxInterv)\<rparr>
            (s\<lparr>minTime := max minInterv (minTime s)\<rparr>) c inps")
       apply simp
-      apply simp
+       apply simp
       apply (simp del:applyAllInputs.simps)
-      by (smt (verit) Semantics.applyAllInputs.simps SemanticsTypes.Environment.select_convs(1) TimeRange.isCompatible.elims(2) TimeRange.isCompatible.simps(1) TimeRange.isCompatible.simps(2) TimeRange.isCompatible.simps(3) TimeRange.isCompatible.simps(4) TimeRange.isValidInterval.simps calculateTimeIntervalAvoidsAmbiguousInterval_applyAllLoop)
+      apply (cases s)
+      apply (simp del:applyAllInputs.simps)
+      subgoal for accounts choices boundValues minTime
+        apply (cases "minInterv \<le> minTime")
+        apply (simp del:applyAllInputs.simps)
+         apply (smt (verit, ccfv_threshold) OptBoundTimeInterval.inInterval.elims(3) OptBoundTimeInterval.inInterval.simps(2) OptBoundTimeInterval.inInterval.simps(3) OptBoundTimeInterval.inInterval.simps(4) TimeRange.isValidInterval.simps calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_applyAllInputs)
+        by (metis Lattices.linorder_class.max.absorb4 Lattices.linorder_class.max.commute TimeRange.isValidInterval.simps calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_applyAllInputs linorder_not_le)
+      done
     done
   done
+
+corollary calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_bounded :
+  "n \<ge> (int (length (inputs tx))) \<Longrightarrow>
+   inInterval (interval tx) (calculateNonAmbiguousInterval (Some n) ct c) \<Longrightarrow>
+   computeTransaction tx s c \<noteq> TransactionError TEAmbiguousTimeIntervalError"
+  using Semantics.geIfNone.simps(2) calculateNonAmbiguousIntervalAvoidsAmbiguousInterval by blast
+
+corollary calculateNonAmbiguousIntervalAvoidsAmbiguousInterval_unbounded :
+  "inInterval (interval tx) (calculateNonAmbiguousInterval None ct c) \<Longrightarrow>
+   computeTransaction tx s c \<noteq> TransactionError TEAmbiguousTimeIntervalError"
+  by (meson Semantics.geIfNone.simps(1) calculateNonAmbiguousIntervalAvoidsAmbiguousInterval)
+
 end

--- a/isabelle/Doc/Specification/document/root.tex
+++ b/isabelle/Doc/Specification/document/root.tex
@@ -83,6 +83,7 @@ Brian Bush
 \input{Examples.tex}
 \input{Swap.tex}
 \input{ByteString.tex}
+\input{OptBoundTimeInterval.tex}
 \input{CodeExports.tex}
 
 % optional bibliography

--- a/isabelle/ROOT
+++ b/isabelle/ROOT
@@ -29,6 +29,7 @@ session Core in "Core" = HOL +
     SemanticsTypes
     SingleInputTransactions
     Timeout
+    TimeRange
     TransactionBound
     ValidState
 

--- a/isabelle/ROOT
+++ b/isabelle/ROOT
@@ -32,6 +32,7 @@ session Core in "Core" = HOL +
     TimeRange
     TransactionBound
     ValidState
+    OptBoundTimeInterval
 
 
 
@@ -86,7 +87,7 @@ session Specification in "Doc/Specification" = HOL +
     "Util"
     "CodeExports"
     "Examples"
-    
+
   theories
     Specification
     Core
@@ -96,6 +97,7 @@ session Specification in "Doc/Specification" = HOL +
   document_theories
     "Core.SemanticsTypes"
     "Core.BlockchainTypes"
+    "Core.OptBoundTimeInterval"
     "CodeExports.CodeExports"
     "Util.ByteString"
     "Examples.Swap"

--- a/isabelle/generated/Arith.hs
+++ b/isabelle/generated/Arith.hs
@@ -2,8 +2,8 @@
 
 module
   Arith(Int(..), equal_int, less_eq_int, less_int, Num(..), One, Zero,
-         Zero_neq_one, uminus_int, zero_int, abs_int, plus_int, minus_int,
-         times_int, of_bool, divide_int)
+         Zero_neq_one, uminus_int, zero_int, abs_int, one_int, plus_int,
+         minus_int, times_int, of_bool, divide_int)
   where {
 
 import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
@@ -73,6 +73,9 @@ zero_int = Int_of_integer (0 :: Integer);
 
 abs_int :: Int -> Int;
 abs_int i = (if less_int i zero_int then uminus_int i else i);
+
+one_int :: Int;
+one_int = Int_of_integer (1 :: Integer);
 
 plus_int :: Int -> Int -> Int;
 plus_int k l = Int_of_integer (integer_of_int k + integer_of_int l);

--- a/isabelle/generated/OptBoundTimeInterval.hs
+++ b/isabelle/generated/OptBoundTimeInterval.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE EmptyDataDecls, RankNTypes, ScopedTypeVariables #-}
+
+module OptBoundTimeInterval(BEndpoint(..), intersectInterval) where {
+
+import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
+  (>>=), (>>), (=<<), (&&), (||), (^), (^^), (.), ($), ($!), (++), (!!), Eq,
+  error, id, return, not, fst, snd, map, filter, concat, concatMap, reverse,
+  zip, null, takeWhile, dropWhile, all, any, Integer, negate, abs, divMod,
+  String, Bool(True, False), Maybe(Nothing, Just));
+import qualified Prelude;
+import qualified Orderings;
+import qualified Arith;
+
+data BEndpoint = Unbounded | Bounded Arith.Int
+  deriving (Prelude.Read, Prelude.Show);
+
+maxLow :: BEndpoint -> BEndpoint -> BEndpoint;
+maxLow Unbounded y = y;
+maxLow (Bounded v) Unbounded = Bounded v;
+maxLow (Bounded x) (Bounded y) = Bounded (Orderings.max x y);
+
+minHigh :: BEndpoint -> BEndpoint -> BEndpoint;
+minHigh Unbounded y = y;
+minHigh (Bounded v) Unbounded = Bounded v;
+minHigh (Bounded x) (Bounded y) = Bounded (Orderings.min x y);
+
+intersectInterval ::
+  (BEndpoint, BEndpoint) -> (BEndpoint, BEndpoint) -> (BEndpoint, BEndpoint);
+intersectInterval (low1, high1) (low2, high2) =
+  (maxLow low1 low2, minHigh high1 high2);
+
+}

--- a/isabelle/generated/SList.hs
+++ b/isabelle/generated/SList.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE EmptyDataDecls, RankNTypes, ScopedTypeVariables #-}
 
-module List(foldl) where {
+module SList(empty, insert) where {
 
 import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
   (>>=), (>>), (=<<), (&&), (||), (^), (^^), (.), ($), ($!), (++), (!!), Eq,
@@ -8,9 +8,15 @@ import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
   zip, null, takeWhile, dropWhile, all, any, Integer, negate, abs, divMod,
   String, Bool(True, False), Maybe(Nothing, Just));
 import qualified Prelude;
+import qualified Orderings;
 
-foldl :: forall a b. (a -> b -> a) -> a -> [b] -> a;
-foldl f a [] = a;
-foldl f a (x : xs) = foldl f (f a x) xs;
+empty :: forall a. (Orderings.Linorder a) => [a];
+empty = [];
+
+insert :: forall a. (Orderings.Linorder a) => a -> [a] -> [a];
+insert a [] = [a];
+insert a (x : z) =
+  (if Orderings.less a x then a : x : z
+    else (if Orderings.less x a then x : insert a z else x : z));
 
 }

--- a/isabelle/generated/Semantics.hs
+++ b/isabelle/generated/Semantics.hs
@@ -8,8 +8,8 @@ module
              evalObservation, txOutWarnings, txOutPayments, reductionLoop,
              reduceContractUntilQuiescent, applyAllInputs, computeTransaction,
              playTrace, getOutcomes, maxTimeContract, getSignatures,
-             calculateTimeInterval, equal_Payment, txOutState, txOutContract,
-             equal_TransactionWarning)
+             calculateNonAmbiguousInterval, equal_Payment, txOutState,
+             txOutContract, equal_TransactionWarning)
   where {
 
 import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
@@ -18,14 +18,15 @@ import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
   zip, null, takeWhile, dropWhile, all, any, Integer, negate, abs, divMod,
   String, Bool(True, False), Maybe(Nothing, Just));
 import qualified Prelude;
+import qualified OptBoundTimeInterval;
 import qualified List;
+import qualified Orderings;
 import qualified Option;
 import qualified MList;
 import qualified HOL;
 import qualified Product_Lexorder;
 import qualified Product_Type;
 import qualified ListTools;
-import qualified Orderings;
 import qualified SList;
 import qualified SemanticsGuarantees;
 import qualified SemanticsTypes;
@@ -112,16 +113,6 @@ addSig acc (SemanticsTypes.IDeposit uu p uv uw) = SList.insert p acc;
 addSig acc (SemanticsTypes.IChoice (SemanticsTypes.ChoiceId ux p) uy) =
   SList.insert p acc;
 addSig acc SemanticsTypes.INotify = acc;
-
-maxOpt :: Maybe Arith.Int -> Maybe Arith.Int -> Maybe Arith.Int;
-maxOpt Nothing y = y;
-maxOpt (Just v) Nothing = Just v;
-maxOpt (Just x) (Just y) = Just (Orderings.max x y);
-
-minOpt :: Maybe Arith.Int -> Maybe Arith.Int -> Maybe Arith.Int;
-minOpt Nothing y = y;
-minOpt (Just v) Nothing = Just v;
-minOpt (Just x) (Just y) = Just (Orderings.min x y);
 
 gtIfNone :: Maybe Arith.Int -> Arith.Int -> Bool;
 gtIfNone Nothing uu = True;
@@ -701,37 +692,39 @@ maxTimeContract (SemanticsTypes.Assert vb contract) = maxTimeContract contract;
 getSignatures :: [SemanticsTypes.Input] -> [SemanticsTypes.Party];
 getSignatures l = List.foldl addSig SList.empty l;
 
-combineIntervals ::
-  (Maybe Arith.Int, Maybe Arith.Int) ->
-    (Maybe Arith.Int, Maybe Arith.Int) -> (Maybe Arith.Int, Maybe Arith.Int);
-combineIntervals (min1, max1) (min2, max2) =
-  (maxOpt min1 min2, minOpt max1 max2);
-
-calculateTimeInterval ::
+calculateNonAmbiguousInterval ::
   Maybe Arith.Int ->
-    Arith.Int -> SemanticsTypes.Contract -> (Maybe Arith.Int, Maybe Arith.Int);
-calculateTimeInterval uu uv SemanticsTypes.Close = (Nothing, Nothing);
-calculateTimeInterval n t (SemanticsTypes.Pay uw ux uy uz c) =
-  calculateTimeInterval n t c;
-calculateTimeInterval n t (SemanticsTypes.If va ct cf) =
-  combineIntervals (calculateTimeInterval n t ct)
-    (calculateTimeInterval n t cf);
-calculateTimeInterval n t (SemanticsTypes.When [] timeout tcont) =
+    Arith.Int ->
+      SemanticsTypes.Contract ->
+        (OptBoundTimeInterval.BEndpoint, OptBoundTimeInterval.BEndpoint);
+calculateNonAmbiguousInterval uu uv SemanticsTypes.Close =
+  (OptBoundTimeInterval.Unbounded, OptBoundTimeInterval.Unbounded);
+calculateNonAmbiguousInterval n t (SemanticsTypes.Pay uw ux uy uz c) =
+  calculateNonAmbiguousInterval n t c;
+calculateNonAmbiguousInterval n t (SemanticsTypes.If va ct cf) =
+  OptBoundTimeInterval.intersectInterval (calculateNonAmbiguousInterval n t ct)
+    (calculateNonAmbiguousInterval n t cf);
+calculateNonAmbiguousInterval n t (SemanticsTypes.When [] timeout tcont) =
   (if Arith.less_int t timeout
-    then (Nothing, Just (Arith.minus_int timeout Arith.one_int))
-    else combineIntervals (Just timeout, Nothing)
-           (calculateTimeInterval n t tcont));
-calculateTimeInterval n t
+    then (OptBoundTimeInterval.Unbounded,
+           OptBoundTimeInterval.Bounded (Arith.minus_int timeout Arith.one_int))
+    else OptBoundTimeInterval.intersectInterval
+           (OptBoundTimeInterval.Bounded timeout,
+             OptBoundTimeInterval.Unbounded)
+           (calculateNonAmbiguousInterval n t tcont));
+calculateNonAmbiguousInterval n t
   (SemanticsTypes.When (SemanticsTypes.Case vb cont : tail) timeout tcont) =
   (if gtIfNone n Arith.zero_int
-    then combineIntervals
-           (calculateTimeInterval (subIfSome n Arith.one_int) t cont)
-           (calculateTimeInterval n t (SemanticsTypes.When tail timeout tcont))
-    else calculateTimeInterval n t (SemanticsTypes.When tail timeout tcont));
-calculateTimeInterval n t (SemanticsTypes.Let vc vd c) =
-  calculateTimeInterval n t c;
-calculateTimeInterval n t (SemanticsTypes.Assert ve c) =
-  calculateTimeInterval n t c;
+    then OptBoundTimeInterval.intersectInterval
+           (calculateNonAmbiguousInterval (subIfSome n Arith.one_int) t cont)
+           (calculateNonAmbiguousInterval n t
+             (SemanticsTypes.When tail timeout tcont))
+    else calculateNonAmbiguousInterval n t
+           (SemanticsTypes.When tail timeout tcont));
+calculateNonAmbiguousInterval n t (SemanticsTypes.Let vc vd c) =
+  calculateNonAmbiguousInterval n t c;
+calculateNonAmbiguousInterval n t (SemanticsTypes.Assert ve c) =
+  calculateNonAmbiguousInterval n t c;
 
 equal_Payment :: Payment -> Payment -> Bool;
 equal_Payment (Payment x1 x2 x3 x4) (Payment y1 y2 y3 y4) =

--- a/isabelle/generated/Semantics.hs
+++ b/isabelle/generated/Semantics.hs
@@ -7,7 +7,8 @@ module
              TransactionOutput(..), Transaction_ext(..), evalValue,
              evalObservation, txOutWarnings, txOutPayments, reductionLoop,
              reduceContractUntilQuiescent, applyAllInputs, computeTransaction,
-             playTrace, equal_Payment, txOutState, txOutContract,
+             playTrace, getOutcomes, maxTimeContract, getSignatures,
+             calculateTimeInterval, equal_Payment, txOutState, txOutContract,
              equal_TransactionWarning)
   where {
 
@@ -17,15 +18,16 @@ import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
   zip, null, takeWhile, dropWhile, all, any, Integer, negate, abs, divMod,
   String, Bool(True, False), Maybe(Nothing, Just));
 import qualified Prelude;
-import qualified Option;
 import qualified List;
-import qualified Orderings;
+import qualified Option;
 import qualified MList;
 import qualified HOL;
-import qualified SemanticsGuarantees;
 import qualified Product_Lexorder;
 import qualified Product_Type;
 import qualified ListTools;
+import qualified Orderings;
+import qualified SList;
+import qualified SemanticsGuarantees;
 import qualified SemanticsTypes;
 import qualified Arith;
 
@@ -103,6 +105,27 @@ quot x y =
     then Arith.divide_int x y
     else Arith.uminus_int
            (Arith.divide_int (Arith.abs_int x) (Arith.abs_int y)));
+
+addSig ::
+  [SemanticsTypes.Party] -> SemanticsTypes.Input -> [SemanticsTypes.Party];
+addSig acc (SemanticsTypes.IDeposit uu p uv uw) = SList.insert p acc;
+addSig acc (SemanticsTypes.IChoice (SemanticsTypes.ChoiceId ux p) uy) =
+  SList.insert p acc;
+addSig acc SemanticsTypes.INotify = acc;
+
+maxOpt :: Maybe Arith.Int -> Maybe Arith.Int -> Maybe Arith.Int;
+maxOpt Nothing y = y;
+maxOpt (Just v) Nothing = Just v;
+maxOpt (Just x) (Just y) = Just (Orderings.max x y);
+
+minOpt :: Maybe Arith.Int -> Maybe Arith.Int -> Maybe Arith.Int;
+minOpt Nothing y = y;
+minOpt (Just v) Nothing = Just v;
+minOpt (Just x) (Just y) = Just (Orderings.min x y);
+
+gtIfNone :: Maybe Arith.Int -> Arith.Int -> Bool;
+gtIfNone Nothing uu = True;
+gtIfNone (Just x) y = Arith.less_int y x;
 
 inBounds :: Arith.Int -> [(Arith.Int, Arith.Int)] -> Bool;
 inBounds num =
@@ -610,6 +633,105 @@ playTrace ::
     SemanticsTypes.Contract -> [Transaction_ext ()] -> TransactionOutput;
 playTrace sl c t =
   playTraceAux (TransactionOutputRecord_ext [] [] (emptyState sl) c ()) t;
+
+subIfSome :: Maybe Arith.Int -> Arith.Int -> Maybe Arith.Int;
+subIfSome Nothing uu = Nothing;
+subIfSome (Just x) y = Just (Arith.minus_int x y);
+
+addOutcome ::
+  SemanticsTypes.Party ->
+    Arith.Int ->
+      [(SemanticsTypes.Party, Arith.Int)] ->
+        [(SemanticsTypes.Party, Arith.Int)];
+addOutcome party diffValue trOut =
+  let {
+    newValue = (case MList.lookup party trOut of {
+                 Nothing -> diffValue;
+                 Just value -> Arith.plus_int value diffValue;
+               });
+  } in MList.insert party newValue trOut;
+
+getPartiesFromReduceEffect ::
+  [ReduceEffect] -> [(SemanticsTypes.Party, (SemanticsTypes.Token, Arith.Int))];
+getPartiesFromReduceEffect
+  (ReduceWithPayment (Payment src (SemanticsTypes.Party p) tok m) : t) =
+  (p, (tok, Arith.uminus_int m)) : getPartiesFromReduceEffect t;
+getPartiesFromReduceEffect (ReduceNoPayment : t) = getPartiesFromReduceEffect t;
+getPartiesFromReduceEffect
+  (ReduceWithPayment (Payment va (SemanticsTypes.Account ve) vc vd) : t) =
+  getPartiesFromReduceEffect t;
+getPartiesFromReduceEffect [] = [];
+
+getPartiesFromInput ::
+  [SemanticsTypes.Input] ->
+    [(SemanticsTypes.Party, (SemanticsTypes.Token, Arith.Int))];
+getPartiesFromInput (SemanticsTypes.IDeposit uu p tok m : t) =
+  (p, (tok, m)) : getPartiesFromInput t;
+getPartiesFromInput (SemanticsTypes.IChoice v va : t) = getPartiesFromInput t;
+getPartiesFromInput (SemanticsTypes.INotify : t) = getPartiesFromInput t;
+getPartiesFromInput [] = [];
+
+emptyOutcome :: [(SemanticsTypes.Party, Arith.Int)];
+emptyOutcome = MList.empty;
+
+getOutcomes ::
+  [ReduceEffect] ->
+    [SemanticsTypes.Input] -> [(SemanticsTypes.Party, Arith.Int)];
+getOutcomes eff inp =
+  List.foldl (\ acc (p, (_, m)) -> addOutcome p m acc) emptyOutcome
+    (getPartiesFromReduceEffect eff ++ getPartiesFromInput inp);
+
+maxTimeCase :: SemanticsTypes.Case -> Arith.Int;
+maxTimeCase (SemanticsTypes.Case vc contract) = maxTimeContract contract;
+
+maxTimeContract :: SemanticsTypes.Contract -> Arith.Int;
+maxTimeContract SemanticsTypes.Close = Arith.zero_int;
+maxTimeContract (SemanticsTypes.Pay uu uv uw ux contract) =
+  maxTimeContract contract;
+maxTimeContract (SemanticsTypes.If uy contractTrue contractFalse) =
+  Orderings.max (maxTimeContract contractTrue) (maxTimeContract contractFalse);
+maxTimeContract (SemanticsTypes.When [] timeout contract) =
+  Orderings.max timeout (maxTimeContract contract);
+maxTimeContract (SemanticsTypes.When (head : tail) timeout contract) =
+  Orderings.max (maxTimeCase head)
+    (maxTimeContract (SemanticsTypes.When tail timeout contract));
+maxTimeContract (SemanticsTypes.Let uz va contract) = maxTimeContract contract;
+maxTimeContract (SemanticsTypes.Assert vb contract) = maxTimeContract contract;
+
+getSignatures :: [SemanticsTypes.Input] -> [SemanticsTypes.Party];
+getSignatures l = List.foldl addSig SList.empty l;
+
+combineIntervals ::
+  (Maybe Arith.Int, Maybe Arith.Int) ->
+    (Maybe Arith.Int, Maybe Arith.Int) -> (Maybe Arith.Int, Maybe Arith.Int);
+combineIntervals (min1, max1) (min2, max2) =
+  (maxOpt min1 min2, minOpt max1 max2);
+
+calculateTimeInterval ::
+  Maybe Arith.Int ->
+    Arith.Int -> SemanticsTypes.Contract -> (Maybe Arith.Int, Maybe Arith.Int);
+calculateTimeInterval uu uv SemanticsTypes.Close = (Nothing, Nothing);
+calculateTimeInterval n t (SemanticsTypes.Pay uw ux uy uz c) =
+  calculateTimeInterval n t c;
+calculateTimeInterval n t (SemanticsTypes.If va ct cf) =
+  combineIntervals (calculateTimeInterval n t ct)
+    (calculateTimeInterval n t cf);
+calculateTimeInterval n t (SemanticsTypes.When [] timeout tcont) =
+  (if Arith.less_int t timeout
+    then (Nothing, Just (Arith.minus_int timeout Arith.one_int))
+    else combineIntervals (Just timeout, Nothing)
+           (calculateTimeInterval n t tcont));
+calculateTimeInterval n t
+  (SemanticsTypes.When (SemanticsTypes.Case vb cont : tail) timeout tcont) =
+  (if gtIfNone n Arith.zero_int
+    then combineIntervals
+           (calculateTimeInterval (subIfSome n Arith.one_int) t cont)
+           (calculateTimeInterval n t (SemanticsTypes.When tail timeout tcont))
+    else calculateTimeInterval n t (SemanticsTypes.When tail timeout tcont));
+calculateTimeInterval n t (SemanticsTypes.Let vc vd c) =
+  calculateTimeInterval n t c;
+calculateTimeInterval n t (SemanticsTypes.Assert ve c) =
+  calculateTimeInterval n t c;
 
 equal_Payment :: Payment -> Payment -> Bool;
 equal_Payment (Payment x1 x2 x3 x4) (Payment y1 y2 y3 y4) =


### PR DESCRIPTION
This PR writes a function in the Isabelle specification to calculate bounds for time intervals given a contract and a concrete time.

When submitting a transaction it needs to have a time interval that fits the contract remaining, otherwise the semantics will issue a `TEAmbiguousTimeIntervalError` error. Calculating a suitable interval is non-trivial. This function makes an effort at maximising an interval while avoiding TEAmbiguousTimeIntervalError errors.

The type of the function `calculateTimeInterval` is `Maybe Integer -> POSIXTime -> Contract -> (Maybe POSIXTime, Maybe POSIXTime)` where the `Integer` would be the number of inputs to consider (where `Nothing` means an arbitrary number), the first `POSIXTime` would be a point in the interval (typically the current time), the `Contract` would be the current remaining contract, and the tuple of `POSIXTime` resulting would be the maximum interval for the given parameters, where `Nothing` would signal the interval is unbounded in that side.

A proof is included for the following properties (expressed as a single property):
- For any transaction with up to `n` inputs that uses the interval resulting from `calculateTimeInterval (Just n) p c` on the contract `c` it is impossible that the result of the transaction is the `TEAmbiguousTimeIntervalError` error
- For any transaction that uses the interval resulting from `calculateTimeInterval Nothing p c` on the contract `c` it is impossible that the result of the transaction is the `TEAmbiguousTimeIntervalError` error
