### PR TITLE
SCP-4698 - Implement roundtrip test for all serialized types

### DIFF
--- a/isabelle/CodeExports/CodeExports.thy
+++ b/isabelle/CodeExports/CodeExports.thy
@@ -66,6 +66,7 @@ export_code
   getSignatures
   maxTimeContract
   calculateNonAmbiguousInterval
+  validAndPositive_state
 
   \<comment> \<open> Export examples to be used as oracle specificaiton tests\<close>
   swapExample

--- a/isabelle/generated/List.hs
+++ b/isabelle/generated/List.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE EmptyDataDecls, RankNTypes, ScopedTypeVariables #-}
 
-module List(foldl) where {
+module List(foldl, distinct, sorted_wrt) where {
 
 import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
   (>>=), (>>), (=<<), (&&), (||), (^), (^^), (.), ($), ($!), (++), (!!), Eq,
@@ -12,5 +12,17 @@ import qualified Prelude;
 foldl :: forall a b. (a -> b -> a) -> a -> [b] -> a;
 foldl f a [] = a;
 foldl f a (x : xs) = foldl f (f a x) xs;
+
+member :: forall a. (Eq a) => [a] -> a -> Bool;
+member [] y = False;
+member (x : xs) y = x == y || member xs y;
+
+distinct :: forall a. (Eq a) => [a] -> Bool;
+distinct [] = True;
+distinct (x : xs) = not (member xs x) && distinct xs;
+
+sorted_wrt :: forall a. (a -> a -> Bool) -> [a] -> Bool;
+sorted_wrt p [] = True;
+sorted_wrt p (x : ys) = all (p x) ys && sorted_wrt p ys;
 
 }

--- a/isabelle/generated/MList.hs
+++ b/isabelle/generated/MList.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE EmptyDataDecls, RankNTypes, ScopedTypeVariables #-}
 
-module MList(empty, delete, insert, lookup, member, findWithDefault) where {
+module MList(empty, delete, insert, lookup, member, valid_map, findWithDefault)
+  where {
 
 import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
   (>>=), (>>), (=<<), (&&), (||), (^), (^^), (.), ($), ($!), (++), (!!), Eq,
@@ -8,6 +9,8 @@ import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
   zip, null, takeWhile, dropWhile, all, any, Integer, negate, abs, divMod,
   String, Bool(True, False), Maybe(Nothing, Just));
 import qualified Prelude;
+import qualified List;
+import qualified HOL;
 import qualified Option;
 import qualified Orderings;
 
@@ -34,6 +37,11 @@ lookup a ((x, y) : z) =
 
 member :: forall a b. (Eq a, Orderings.Linorder a) => a -> [(a, b)] -> Bool;
 member k d = not (Option.is_none (lookup k d));
+
+valid_map :: forall a b. (Eq a, Orderings.Linorder a) => [(a, b)] -> Bool;
+valid_map x = let {
+                y = map fst x;
+              } in List.distinct y && List.sorted_wrt Orderings.less_eq y;
 
 findWithDefault ::
   forall a b. (Eq b, Orderings.Linorder b) => a -> b -> [(b, a)] -> a;

--- a/isabelle/generated/PositiveAccounts.hs
+++ b/isabelle/generated/PositiveAccounts.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE EmptyDataDecls, RankNTypes, ScopedTypeVariables #-}
+
+module PositiveAccounts(validAndPositive_state) where {
+
+import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
+  (>>=), (>>), (=<<), (&&), (||), (^), (^^), (.), ($), ($!), (++), (!!), Eq,
+  error, id, return, not, fst, snd, map, filter, concat, concatMap, reverse,
+  zip, null, takeWhile, dropWhile, all, any, Integer, negate, abs, divMod,
+  String, Bool(True, False), Maybe(Nothing, Just));
+import qualified Prelude;
+import qualified SemanticsGuarantees;
+import qualified Product_Type;
+import qualified List;
+import qualified SemanticsTypes;
+import qualified Arith;
+
+allAccountsPositive ::
+  [((SemanticsTypes.Party, SemanticsTypes.Token), Arith.Int)] -> Bool;
+allAccountsPositive accs =
+  List.foldl
+    (\ r (a, b) ->
+      (case a of {
+        (_, _) -> (\ money -> r && Arith.less_int Arith.zero_int money);
+      })
+        b)
+    True accs;
+
+allAccountsPositiveState :: SemanticsTypes.State_ext () -> Bool;
+allAccountsPositiveState state =
+  allAccountsPositive (SemanticsTypes.accounts state);
+
+validAndPositive_state :: SemanticsTypes.State_ext () -> Bool;
+validAndPositive_state state =
+  SemanticsGuarantees.valid_state state && allAccountsPositiveState state;
+
+}

--- a/isabelle/generated/SemanticsGuarantees.hs
+++ b/isabelle/generated/SemanticsGuarantees.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE EmptyDataDecls, RankNTypes, ScopedTypeVariables #-}
 
-module SemanticsGuarantees() where {
+module SemanticsGuarantees(valid_state) where {
 
 import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
   (>>=), (>>), (=<<), (&&), (||), (^), (^^), (.), ($), ($!), (++), (!!), Eq,
@@ -9,6 +9,9 @@ import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
   String, Bool(True, False), Maybe(Nothing, Just));
 import qualified Prelude;
 import qualified ByteString;
+import qualified MList;
+import qualified Arith;
+import qualified Product_Lexorder;
 import qualified SemanticsTypes;
 import qualified Orderings;
 
@@ -122,5 +125,11 @@ instance Orderings.Order SemanticsTypes.ChoiceId where {
 
 instance Orderings.Linorder SemanticsTypes.ChoiceId where {
 };
+
+valid_state :: SemanticsTypes.State_ext () -> Bool;
+valid_state state =
+  MList.valid_map (SemanticsTypes.accounts state) &&
+    MList.valid_map (SemanticsTypes.choices state) &&
+      MList.valid_map (SemanticsTypes.boundValues state);
 
 }

--- a/isabelle/marlowe.cabal
+++ b/isabelle/marlowe.cabal
@@ -38,7 +38,6 @@ library
         OptBoundTimeInterval
         Product_Lexorder
         Product_Type
-        SemanticsGuarantees
         SList
         Stringa
     exposed-modules:
@@ -49,6 +48,7 @@ library
         MarloweCoreJson
         Semantics
         SemanticsTypes
+        SemanticsGuarantees
 
 test-suite marlowe-spec-test-suite
     default-language: Haskell2010

--- a/marlowe-spec-test/src/Marlowe/Spec/Core/Arbitrary.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/Core/Arbitrary.hs
@@ -2,11 +2,12 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Marlowe.Spec.Core.Arbitrary where
 
-import SemanticsTypes (Token(..), Party)
-import QuickCheck.GenT (GenT)
+import SemanticsTypes (Token(..), Party, Payee(..), ChoiceId (ChoiceId), Bound(..), Value(..), ValueId(..), Observation(..), Action (..), Case(..), Contract (..), Input (..), State_ext(..), IntervalError (..))
+import QuickCheck.GenT (GenT, arbitrary', MonadGen (..), suchThat, frequency, sized, resize, scale)
 import Marlowe.Spec.Interpret (InterpretJsonRequest, Request (..), parseValidResponse)
 import Data.Data (Proxy(..))
 import Marlowe.Spec.TypeId (TypeId(..))
@@ -15,6 +16,12 @@ import Control.Exception (throwIO, Exception)
 import Data.Aeson (FromJSON(..), withObject, (.:), (.=))
 import Control.Applicative ((<|>))
 import Data.Aeson (ToJSON (..), object)
+import Test.QuickCheck (Gen, chooseInt)
+import QuickCheck.GenT (Arbitrary(..), vectorOf)
+import qualified Arith
+import Semantics (Transaction_ext(..), Payment(..), TransactionWarning (..), TransactionError (..), TransactionOutput(..), TransactionOutputRecord_ext (..))
+import Control.Monad (liftM2)
+import SemanticsGuarantees (valid_state)
 
 data RandomResponse a
   = RandomValue a
@@ -39,8 +46,44 @@ instance FromJSON a => FromJSON (RandomResponse a) where
 data GenerateRandomValueException = GenerateRandomValueException String
   deriving (Show, Exception)
 
-arbitraryToken :: InterpretJsonRequest -> GenT IO Token
-arbitraryToken interpret = liftIO do
+
+-- | Part of the Fibonacci sequence.
+fibonaccis :: Num a => [a]
+fibonaccis = [2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584]
+
+
+-- | Inverse-Fibanoncci frequencies.
+fibonacciFrequencies :: Integral a => [a]
+fibonacciFrequencies = (1000000 `div`) <$> fibonaccis
+
+
+-- | Select an element of a list with propability proportional to inverse-Fibonacci weights.
+arbitraryFibonacci :: [a] -> Gen a
+arbitraryFibonacci = frequency . zip fibonacciFrequencies . fmap pure
+
+
+-- | An arbitrary integer, mostly small.
+arbitraryInteger :: Gen Arith.Int
+arbitraryInteger = Arith.Int_of_integer <$>
+  frequency
+    [
+      ( 5, arbitrary `suchThat` (< 0))
+    , (30, arbitrary `suchThat` (> 0))
+    , ( 5, pure 0)
+    , (60, arbitraryFibonacci fibonaccis)
+    ]
+
+-- | An arbitrary non-negative integer, mostly small.
+arbitraryNonnegativeInteger :: Gen Arith.Int
+arbitraryNonnegativeInteger = Arith.Int_of_integer <$>
+  frequency
+    [
+      (60, arbitrary `suchThat` (>= 0))
+    , (30, arbitraryFibonacci fibonaccis)
+    ]
+
+genToken :: InterpretJsonRequest -> GenT IO Token
+genToken interpret = liftIO do
   res <- interpret (GenerateRandomValue $ TypeId "Core.Token" (Proxy :: Proxy Token))
   case parseValidResponse res of
     Left err -> throwIO $ GenerateRandomValueException err
@@ -48,10 +91,273 @@ arbitraryToken interpret = liftIO do
     Right (RandomValue t) -> pure t
 
 
-arbitraryParty :: InterpretJsonRequest -> GenT IO Party
-arbitraryParty interpret = liftIO do
+genParty :: InterpretJsonRequest -> GenT IO Party
+genParty interpret = liftIO do
   res <- interpret (GenerateRandomValue $ TypeId "Core.Party" (Proxy :: Proxy Party))
   case parseValidResponse res of
     Left err -> throwIO $ GenerateRandomValueException err
     Right (UnknownType _) -> throwIO $ GenerateRandomValueException "Client process doesn't know how to generate Core.Party"
     Right (RandomValue t) -> pure t
+
+genPayee ::  InterpretJsonRequest -> GenT IO Payee
+genPayee i = do
+  isParty <- arbitrary'
+  if isParty
+    then Party <$> genParty i
+    else Account <$> genParty i
+
+-- | Some choice names.
+randomChoiceNames :: [String]
+randomChoiceNames =
+  [
+    "be"
+  , "dry"
+  , "grab"
+  , "weigh"
+  , "enable"
+  , "enhance"
+  , "allocate"
+  , ""
+  , "originate"
+  , "characterize"
+  , "derive witness"
+  , "envisage software"
+  , "attend unknown animals"
+  , "position increated radiation"
+  , "proclaim endless sordid figments"
+  , "understand weigh originate envisage"  -- NB: Too long for ledger.
+  ]
+
+-- | Generate a choice name from a few possibilities.
+arbitraryChoiceName :: Gen String
+arbitraryChoiceName = arbitraryFibonacci randomChoiceNames
+
+genChoiceId :: InterpretJsonRequest -> GenT IO ChoiceId
+genChoiceId i = ChoiceId <$> liftGen arbitraryChoiceName <*> genParty i
+
+-- | Some value identifiers.
+randomValueIds :: [ValueId]
+randomValueIds = ValueId <$>
+  [
+    "x"
+  , "id"
+  , "lab"
+  , "idea"
+  , "story"
+  , "memory"
+  , "fishing"
+  , ""
+  , "drawing"
+  , "reaction"
+  , "difference"
+  , "replacement"
+  , "paper apartment"
+  , "leadership information"
+  , "entertainment region assumptions"
+  , "candidate apartment reaction replacement"  -- NB: Too long for ledger.
+  ]
+
+genValueId :: Gen ValueId
+genValueId = arbitraryFibonacci randomValueIds
+
+genBound :: Gen Bound
+genBound = do
+  lower <- arbitraryInteger
+  extent <- arbitraryNonnegativeInteger
+  pure $ Bound lower (lower + extent)
+
+genValue :: InterpretJsonRequest -> GenT IO Value
+genValue i = sized (
+  \case n | n <= 1 ->
+            frequency
+              [ (80, genConstant)
+              , (10, genTimeIntervalStart)
+              , (10, genTimeIntervalEnd)
+              ]
+          | n == 2 ->
+            frequency
+              [ (45, genConstant)
+              , (8, genTimeIntervalStart)
+              , (8, genTimeIntervalEnd)
+              , (13, genNegValue)
+              , (13, genUseValue)
+              , (13, genChoiceValue)
+              ]
+          | otherwise ->
+            frequency
+              [ ( 8, genAvailableMoney)
+              , (14, genConstant)
+              , ( 8, resize (n - 1) $ genNegValue)
+              , ( 8, resize (n - 2) $ genAddValue)
+              , ( 8, resize (n - 2) $ genSubValue)
+              , ( 8, resize (n - 2) $ genMulValue)
+              , ( 8, resize (n - 2) $ genDivValue)
+              , (10, genChoiceValue)
+              , ( 6, genTimeIntervalStart)
+              , ( 6, genTimeIntervalEnd)
+              , ( 8, genUseValue)
+              , ( 8, resize (n - 3) $ genCond)
+              ]
+  )
+  where
+  genAvailableMoney = AvailableMoney <$> genParty i <*> genToken i
+  genConstant = Constant <$> liftGen arbitraryInteger
+  genNegValue = NegValue <$> genValue i
+  genAddValue = AddValue <$> genValue i <*> genValue i
+  genSubValue = SubValue <$> genValue i <*> genValue i
+  genMulValue = MulValue <$> genValue i <*> genValue i
+  genDivValue = DivValue <$> genValue i <*> genValue i
+  genChoiceValue = ChoiceValue <$> genChoiceId i
+  genTimeIntervalStart = pure TimeIntervalStart
+  genTimeIntervalEnd = pure TimeIntervalEnd
+  genUseValue = UseValue <$> liftGen genValueId
+  genCond = Cond <$> genObservation i <*> genValue i <*> genValue i
+
+genObservation :: InterpretJsonRequest -> GenT IO Observation
+genObservation i = sized (
+  \case n | n <= 1 -> frequency
+            [ (10, genChoseSomething)
+            , (45, genTrue)
+            , (45, genFalse)
+            ]
+          | otherwise -> frequency
+            [ ( 8, resize (n - 2) $ genAndObs)
+            , ( 8, resize (n - 2) $ genOrObs)
+            , ( 8, resize (n - 1) $ genNotObs)
+            , (16, genChoseSomething)
+            , ( 8, resize (n - 2) $ genValueGE)
+            , ( 8, resize (n - 2) $ genValueGT)
+            , ( 8, resize (n - 2) $ genValueLT)
+            , ( 8, resize (n - 2) $ genValueLE)
+            , ( 8, resize (n - 2) $ genValueEQ)
+            , (10, genTrue)
+            , (10, genFalse)
+            ]
+  )
+  where
+  genAndObs = AndObs <$> genObservation i <*> genObservation i
+  genOrObs = OrObs <$> genObservation i <*> genObservation i
+  genNotObs = NotObs <$> genObservation i
+  genChoseSomething = ChoseSomething <$> genChoiceId i
+  genValueGE = ValueGE <$> genValue i <*> genValue i
+  genValueGT = ValueGT <$> genValue i <*> genValue i
+  genValueLT = ValueLT <$> genValue i <*> genValue i
+  genValueLE = ValueLE <$> genValue i <*> genValue i
+  genValueEQ = ValueEQ <$> genValue i <*> genValue i
+  genTrue = pure TrueObs
+  genFalse = pure FalseObs
+
+genAction :: InterpretJsonRequest -> GenT IO Action
+genAction i = frequency
+      [ (4, Deposit <$> genParty i <*> genParty i <*> genToken i <*> genValue i)
+      , (5, do
+          lSize <- liftGen $ chooseInt (1, 4)
+          Choice <$> genChoiceId i <*> vectorOf lSize (liftGen genBound)
+        )
+      , (1, Notify <$> genObservation i)
+      ]
+
+genCase :: InterpretJsonRequest -> GenT IO Case
+genCase i = Case <$> genAction i <*> genContract i
+
+genContract :: InterpretJsonRequest -> GenT IO Contract
+genContract i = sized (
+  \case n | n <= 1 -> genClose
+          | otherwise -> frequency
+            [ ( 30, genClose)
+            , ( 20, genPay n)
+            , ( 15, genIf n)
+            , ( 20, genWhen n)
+            , ( 10, genLet n)
+            , ( 5, genAssert n)
+            ]
+  )
+  where
+  genClose = pure Close
+  genPay n = Pay <$> genParty i <*> genPayee i <*> genToken i <*> limit (genValue i) <*> resize (n - 1) (genContract i)
+  genIf n = If <$> limit  (genObservation i) <*> resize (n - 1) (genContract i) <*> resize (n - 1) (genContract i)
+  genWhen n = do
+    lSize <- liftGen $ chooseInt (0, 3)
+    cases <- vectorOf lSize (resize (n - lSize) (genCase i))
+    timeout <- liftGen $ arbitraryInteger
+    cont <- resize (n - 1) (genContract i)
+    pure $ When cases timeout cont
+  genLet n = Let <$> liftGen genValueId <*> limit (genValue i) <*> resize (n - 1) (genContract i)
+  genAssert n = Assert <$> limit (genObservation i) <*> resize (n - 1) (genContract i)
+  limit = scale (min 3)
+
+genInput :: InterpretJsonRequest -> GenT IO Input
+genInput i = frequency
+  [ (50, IDeposit <$> genParty i <*> genParty i <*> genToken i <*> liftGen arbitraryInteger)
+  , (45, IChoice <$> genChoiceId i <*> liftGen arbitraryInteger )
+  , (5, pure INotify)
+  ]
+
+genTransaction :: InterpretJsonRequest -> GenT IO (Transaction_ext ())
+genTransaction i = do
+  lower <- liftGen $ arbitraryInteger
+  extent <- liftGen $ arbitraryNonnegativeInteger
+  iSize <- liftGen $ chooseInt (0, 4)
+  inputs <- vectorOf iSize (genInput i)
+  pure $ Transaction_ext (lower, lower + extent) inputs ()
+
+genPayment ::  InterpretJsonRequest -> GenT IO Payment
+genPayment i = Payment <$> genParty i <*> genPayee i <*> genToken i <*> liftGen arbitraryInteger
+
+(>*<) :: Monad m => GenT m a -> GenT m b -> GenT m (a, b)
+genA >*< genB = liftM2 (,) genA genB
+
+genState :: InterpretJsonRequest -> GenT IO (State_ext ())
+genState i = rawGen `suchThat` valid_state
+  where
+  rawGen = sized
+    (\n ->  do
+      accountSize <- liftGen $ chooseInt (0, min n 4)
+      choiceSize <- liftGen $ chooseInt (0, min n 4)
+      boundSize <- liftGen $ chooseInt (0, min n 4)
+      accounts <- vectorOf accountSize ((genParty i >*< genToken i) >*< liftGen arbitraryNonnegativeInteger)
+      choices <- vectorOf choiceSize (genChoiceId i >*< liftGen arbitraryInteger)
+      bounds <- vectorOf boundSize (liftGen genValueId >*< liftGen arbitraryInteger)
+      minTime <- liftGen arbitraryInteger
+      pure $ State_ext accounts choices bounds minTime ()
+    )
+genTransactionWarning :: InterpretJsonRequest -> GenT IO TransactionWarning
+genTransactionWarning i = frequency
+  [ ( 30, TransactionNonPositiveDeposit <$> genParty i <*> genParty i <*> genToken i <*> liftGen arbitraryInteger)
+  , ( 30, TransactionNonPositivePay <$> genParty i <*> genPayee i <*> genToken i <*> liftGen arbitraryInteger)
+  , ( 30, TransactionShadowing <$> liftGen genValueId <*> liftGen arbitraryInteger <*> liftGen arbitraryInteger)
+  , ( 10, pure TransactionAssertionFailed)
+  ]
+
+
+genIntervalError :: Gen IntervalError
+genIntervalError = do
+  lower <- arbitraryInteger
+  extent <- arbitraryNonnegativeInteger
+  frequency
+    [ (1, pure $ InvalidInterval (lower, lower + extent))
+    , (1, IntervalInPastError <$> liftGen arbitraryNonnegativeInteger <*> pure  (lower, lower + extent) )
+    ]
+
+genTransactionError :: Gen TransactionError
+genTransactionError = frequency
+    [ (1, pure TEAmbiguousTimeIntervalError)
+    , (1, pure TEApplyNoMatchError)
+    , (1, TEIntervalError <$> genIntervalError)
+    , (1, pure TEUselessTransaction)
+    ]
+
+genTransactionOutput :: InterpretJsonRequest -> GenT IO TransactionOutput
+genTransactionOutput i =
+ frequency
+    [ (30, TransactionError <$> liftGen genTransactionError)
+    , (70, do
+              wSize <- liftGen $ chooseInt (0, 2)
+              warnings <- vectorOf wSize $ genTransactionWarning i
+              pSize <- liftGen $ chooseInt (0, 2)
+              payments <- vectorOf pSize $ genPayment i
+              state <- resize 2 $ genState i
+              contract <- resize 2 $ genContract i
+              pure $ TransactionOutput $ TransactionOutputRecord_ext warnings payments state contract ()
+      )
+    ]

--- a/marlowe-spec-test/src/Marlowe/Spec/Core/Serialization/Json.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/Core/Serialization/Json.hs
@@ -19,13 +19,13 @@ import GHC.Stack (HasCallStack)
 import Test.Tasty (TestTree, testGroup)
 import Marlowe.Spec.Interpret (Response (..), InterpretJsonRequest, Request (..), testResponse)
 import Marlowe.Spec.TypeId (TypeId(..), HasTypeId (..))
-import Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
+import Test.Tasty.HUnit (Assertion, assertBool, testCase, (@=?))
 import qualified SemanticsTypes as C
-import QuickCheck.GenT (runGenT)
-import Marlowe.Spec.Core.Arbitrary (arbitraryToken, arbitraryParty)
-import Test.QuickCheck (generate)
+import QuickCheck.GenT (runGenT, MonadGen (resize))
+import Marlowe.Spec.Core.Arbitrary (genToken, genParty, genPayee, genChoiceId, genBound, genValue, genObservation, genAction, genContract, genInput, genTransaction, genPayment, genState, genTransactionWarning, genIntervalError, genTransactionError, genTransactionOutput)
+import Test.QuickCheck (generate, counterexample)
 import Test.Tasty.QuickCheck (testProperty)
-import Test.QuickCheck.Monadic (monadicIO, run)
+import Test.QuickCheck.Monadic (monadicIO, run, PropertyM, assert, monitor)
 
 
 data SerializationResponse transport
@@ -53,31 +53,53 @@ instance FromJSON (SerializationResponse JSON.Value) where
     asUnknownType v = UnknownType <$> v .: "unknown-type"
     asError v = SerializationError <$> v .: "serialization-error"
 
-
 tests :: InterpretJsonRequest -> TestTree
 tests i = testGroup "Json Serialization"
-  [ testCase "Bound example" $ roundtripTest i condExample
-  , valueTests i
-  , observationTests i
-  , invalidType i
-  , tokenTest i
-  , partyTest i
+  [ exampleTest i
+  , arbitraryTests i
   ]
 
-valueTests :: InterpretJsonRequest -> TestTree
-valueTests i = testGroup "Value examples"
-  [ testCase "Constant" $ roundtripTest i constantExample
-  , testCase "Interval start" $ roundtripTest i intervalStartExample
-  , testCase "Interval end" $ roundtripTest i intervalEndExample
-  , testCase "Add" $ roundtripTest i addExample
-  , testCase "Sub" $ roundtripTest i subExample
-  , testCase "Mul" $ roundtripTest i mulExample
-  , testCase "Div" $ roundtripTest i divExample
-  , testCase "Negate" $ roundtripTest i negateExample
-  -- , testCase "Choice value" $ roundtripTest i choiceValueExample
-  , testCase "Use" $ roundtripTest i useValueExample
-  , testCase "Cond" $ roundtripTest i condExample
-  -- ,testCase "Available money" $ roundtripTest i availableMoneyExample
+exampleTest :: InterpretJsonRequest -> TestTree
+exampleTest i = testGroup "Examples"
+  [ testCase "Bound example" $ unitRoundtripTest i exampleBound
+  , valueExamples i
+  , observationTests i
+  , invalidType i
+  ]
+
+arbitraryTests :: InterpretJsonRequest -> TestTree
+arbitraryTests i = testGroup "Arbitrary"
+  [ arbitraryTokenTest i
+  , arbitraryPartyTest i
+  , arbitraryPayeeTest i
+  , arbitraryChoiceIdTest i
+  , arbitraryBoundTest i
+  , arbitraryValueTest i
+  , arbitraryObservationTest i
+  , arbitraryActionTest i
+  , arbitraryContractTest i
+  , arbitraryInputTest i
+  , arbitraryTransactionTest i
+  , arbitraryPaymentTest i
+  , arbitraryStateTest i
+  , arbitraryTransactionWarningTest i
+  , arbitraryIntervalErrorTest i
+  , arbitraryTransactionErrorTest i
+  , arbitraryTransactionOutputTest i
+  ]
+
+valueExamples :: InterpretJsonRequest -> TestTree
+valueExamples i = testGroup "Value examples"
+  [ testCase "Constant" $ unitRoundtripTest i constantExample
+  , testCase "Interval start" $ unitRoundtripTest i intervalStartExample
+  , testCase "Interval end" $ unitRoundtripTest i intervalEndExample
+  , testCase "Add" $ unitRoundtripTest i addExample
+  , testCase "Sub" $ unitRoundtripTest i subExample
+  , testCase "Mul" $ unitRoundtripTest i mulExample
+  , testCase "Div" $ unitRoundtripTest i divExample
+  , testCase "Negate" $ unitRoundtripTest i negateExample
+  , testCase "Use" $ unitRoundtripTest i useValueExample
+  , testCase "Cond" $ unitRoundtripTest i condExample
   , testResponse i "Invalid value"
     (TestRoundtripSerialization
       (TypeId "Core.Value" (Proxy @C.Value))
@@ -88,48 +110,49 @@ valueTests i = testGroup "Value examples"
 
 observationTests :: InterpretJsonRequest -> TestTree
 observationTests i = testGroup "Observation examples"
-  [ testCase "True" $ roundtripTest i trueExample
-  , testCase "False" $ roundtripTest i falseExample
-  , testCase "And" $ roundtripTest i andExample
-  , testCase "Or" $ roundtripTest i orExample
-  , testCase "Not" $ roundtripTest i notExample
-  -- , testCase "Chose" $ roundtripTest i choseExample
-  , testCase "Value GE" $ roundtripTest i valueGEExample
-  , testCase "Value GT" $ roundtripTest i valueGTExample
-  , testCase "Value LT" $ roundtripTest i valueLTExample
-  , testCase "Value LE" $ roundtripTest i valueLEExample
-  , testCase "Value EQ" $ roundtripTest i valueEQExample
+  [ testCase "True" $ unitRoundtripTest i trueExample
+  , testCase "False" $ unitRoundtripTest i falseExample
+  , testCase "And" $ unitRoundtripTest i andExample
+  , testCase "Or" $ unitRoundtripTest i orExample
+  , testCase "Not" $ unitRoundtripTest i notExample
+  , testCase "Value GE" $ unitRoundtripTest i valueGEExample
+  , testCase "Value GT" $ unitRoundtripTest i valueGTExample
+  , testCase "Value LT" $ unitRoundtripTest i valueLTExample
+  , testCase "Value LE" $ unitRoundtripTest i valueLEExample
+  , testCase "Value EQ" $ unitRoundtripTest i valueEQExample
   , testResponse i "Invalid observation"
     (TestRoundtripSerialization (TypeId "Core.Observation" (Proxy :: Proxy C.Observation)) (JSON.String "invalid"))
     assertSerializationError
 
   ]
 
-tokenTest :: InterpretJsonRequest -> TestTree
-tokenTest i = testProperty "Token test" $ monadicIO $ run do
-  -- Any token that is randomly generated by the interpreter should also pass the roundtrip test
-  token <- join $ generate $ runGenT $ arbitraryToken i
-  roundtripTest i token
-
-partyTest :: InterpretJsonRequest -> TestTree
-partyTest i = testProperty "Party test" $ monadicIO $ run do
-  -- Any party that is randomly generated by the interpreter should also pass the roundtrip test
-  party <- join $ generate $ runGenT $ arbitraryParty i
-  roundtripTest i party
-
-
 invalidType :: InterpretJsonRequest -> TestTree
 invalidType i = testResponse i "Invalid type"
     (TestRoundtripSerialization (TypeId "InvalidType" (Proxy :: Proxy ())) (JSON.String "invalid"))
     assertUnknownType
 
-roundtripTest :: (HasTypeId a, ToJSON a) => InterpretJsonRequest -> a -> Assertion
-roundtripTest interpret a = do
+unitRoundtripTest :: (HasTypeId a, ToJSON a) => InterpretJsonRequest -> a -> Assertion
+unitRoundtripTest interpret a = do
   res <- interpret serializationRequest
-  successResponse @?= res
+  successResponse @=? res
   where
   serializationRequest = TestRoundtripSerialization (getTypeId a) $ toJSON a
   successResponse = RequestResponse $ toJSON $ SerializationSuccess $ toJSON a
+
+propertyRoundtripTest :: (HasTypeId a, ToJSON a) => InterpretJsonRequest -> a -> PropertyM IO ()
+propertyRoundtripTest interpret a = do
+  res <- run $ interpret serializationRequest
+  monitor (
+    counterexample $
+      "Request: " ++ show serializationRequest ++ "\n" ++
+      "Expected: " ++ show successResponse ++ "\n" ++
+      "Actual: " ++ show res
+    )
+  assert $ successResponse == res
+  where
+  serializationRequest = TestRoundtripSerialization (getTypeId a) $ toJSON a
+  successResponse = RequestResponse $ toJSON $ SerializationSuccess $ toJSON a
+
 
 assertSerializationError :: HasCallStack => Response JSON.Value -> Assertion
 assertSerializationError = assertBool "The serialization response should be SerializationError" . isSerializationError
@@ -148,3 +171,93 @@ isUnknownType (RequestResponse res) = case JSON.fromJSON res :: Result (Serializ
   (Success (UnknownType _)) -> True
   _ -> False
 isUnknownType _ = False
+
+arbitraryTokenTest :: InterpretJsonRequest -> TestTree
+arbitraryTokenTest i = testProperty "Token" $ monadicIO do
+  -- Any token that is randomly generated by the interpreter should also pass the roundtrip test
+  token <- run $ join $ generate $ runGenT $ genToken i
+  propertyRoundtripTest i token
+
+arbitraryPartyTest :: InterpretJsonRequest -> TestTree
+arbitraryPartyTest i = testProperty "Party" $ monadicIO do
+  -- Any party that is randomly generated by the interpreter should also pass the roundtrip test
+  party <- run $ join $ generate $ runGenT $ genParty i
+  propertyRoundtripTest i party
+
+arbitraryPayeeTest :: InterpretJsonRequest -> TestTree
+arbitraryPayeeTest i = testProperty "Payee" $ monadicIO do
+  payee <- run $ join $ generate $ runGenT $ genPayee i
+  propertyRoundtripTest i payee
+
+arbitraryChoiceIdTest :: InterpretJsonRequest -> TestTree
+arbitraryChoiceIdTest i = testProperty "ChoiceId" $ monadicIO do
+  choiceId <- run $ join $ generate $ runGenT $ genChoiceId i
+  propertyRoundtripTest i choiceId
+
+arbitraryBoundTest :: InterpretJsonRequest -> TestTree
+arbitraryBoundTest i = testProperty "Bound" $ monadicIO do
+  bound <- run $ generate genBound
+  propertyRoundtripTest i bound
+
+arbitraryValueTest :: InterpretJsonRequest -> TestTree
+arbitraryValueTest i = testProperty "Value" $ monadicIO do
+  value <- run $ join $ generate $ resize 15 $ runGenT $ genValue i
+  propertyRoundtripTest i value
+
+arbitraryObservationTest :: InterpretJsonRequest -> TestTree
+arbitraryObservationTest i = testProperty "Observation" $ monadicIO do
+  observation <- run $ join $ generate $ resize 15 $ runGenT $ genObservation i
+  propertyRoundtripTest i observation
+
+arbitraryActionTest :: InterpretJsonRequest -> TestTree
+arbitraryActionTest i = testProperty "Action" $ monadicIO do
+  action <- run $ join $ generate $ resize 15 $ runGenT $ genAction i
+  propertyRoundtripTest i action
+
+arbitraryContractTest :: InterpretJsonRequest -> TestTree
+arbitraryContractTest i = testProperty "Contract" $ monadicIO do
+  contract <- run $ join $ generate $ resize 10 $ runGenT $ genContract i
+  propertyRoundtripTest i contract
+
+arbitraryInputTest :: InterpretJsonRequest -> TestTree
+arbitraryInputTest i = testProperty "Input" $ monadicIO do
+  input <- run $ join $ generate $ runGenT $ genInput i
+  propertyRoundtripTest i input
+
+arbitraryTransactionTest :: InterpretJsonRequest -> TestTree
+arbitraryTransactionTest i = testProperty "Transaction" $ monadicIO do
+  tx <- run $ join $ generate $ runGenT $ genTransaction i
+  propertyRoundtripTest i tx
+
+arbitraryPaymentTest :: InterpretJsonRequest -> TestTree
+arbitraryPaymentTest i = testProperty "Payment" $ monadicIO do
+  payment <- run $ join $ generate $ runGenT $ genPayment i
+  propertyRoundtripTest i payment
+
+arbitraryStateTest :: InterpretJsonRequest -> TestTree
+arbitraryStateTest i = testProperty "State" $ monadicIO do
+  state <- run $ join $ generate $ runGenT $ genState i
+  propertyRoundtripTest i state
+
+arbitraryTransactionWarningTest :: InterpretJsonRequest -> TestTree
+arbitraryTransactionWarningTest i = testProperty "TransactionWarning" $ monadicIO do
+  warning <- run $ join $ generate $ runGenT $ genTransactionWarning i
+  propertyRoundtripTest i warning
+
+arbitraryIntervalErrorTest :: InterpretJsonRequest -> TestTree
+arbitraryIntervalErrorTest i = testProperty "IntervalError" $ monadicIO do
+  warning <- run $ generate $ genIntervalError
+  propertyRoundtripTest i warning
+
+arbitraryTransactionErrorTest :: InterpretJsonRequest -> TestTree
+arbitraryTransactionErrorTest i = testProperty "TransactionError" $ monadicIO do
+  txError <- run $ generate $ genTransactionError
+  propertyRoundtripTest i txError
+
+arbitraryTransactionOutputTest :: InterpretJsonRequest -> TestTree
+arbitraryTransactionOutputTest i = testProperty "TransactionOutput" $ monadicIO do
+  out <- run $ join $ generate $ runGenT $ genTransactionOutput i
+  propertyRoundtripTest i out
+
+
+

--- a/marlowe-spec-test/src/Marlowe/Spec/LocalInterpret.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/LocalInterpret.hs
@@ -14,6 +14,7 @@ import Data.Aeson (Result (..),FromJSON,ToJSON)
 import SemanticsTypes (Token(Token), Party (..))
 import Test.QuickCheck (Gen, frequency, Arbitrary (arbitrary), generate)
 import qualified Marlowe.Spec.Core.Arbitrary as RandomResponse
+import Marlowe.Spec.Core.Arbitrary (arbitraryFibonacci)
 
 
 interpretLocal :: Request JSON.Value -> IO (Response JSON.Value)
@@ -69,20 +70,6 @@ randomRoleNames =
   , "Urbanus Roland Alison Ty Ryoichi"
   , "Alcippe Alende Blanka Roland Dafne"  -- NB: Too long for Cardano ledger.
   ]
-
--- | Part of the Fibonacci sequence.
-fibonaccis :: Num a => [a]
-fibonaccis = [2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584]
-
-
--- | Inverse-Fibanoncci frequencies.
-fibonacciFrequencies :: Integral a => [a]
-fibonacciFrequencies = (1000000 `div`) <$> fibonaccis
-
-
--- | Select an element of a list with propability proportional to inverse-Fibonacci weights.
-arbitraryFibonacci :: [a] -> Gen a
-arbitraryFibonacci = frequency . zip fibonacciFrequencies . fmap pure
 
 
 arbitraryParty :: Gen Party

--- a/marlowe-spec-test/src/Marlowe/Spec/TypeId.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/TypeId.hs
@@ -16,6 +16,9 @@ import qualified Data.Text as T
 
 data TypeId = forall a. (ToJSON a, FromJSON a) => TypeId String (Proxy a)
 
+instance Show TypeId where
+  show (TypeId name _) = name
+
 instance Eq TypeId where
   (TypeId t1 _) == (TypeId t2 _) = (t1 == t2)
 
@@ -37,6 +40,7 @@ fromTypeName name = case name of
   "Core.TransactionError" -> Just $ TypeId "Core.TransactionError" (Proxy :: Proxy C.TransactionError)
   "Core.TransactionOutput" -> Just $ TypeId "Core.TransactionOutput" (Proxy :: Proxy C.TransactionOutput)
   "Core.TransactionWarning" -> Just $ TypeId "Core.TransactionWarning" (Proxy :: Proxy C.TransactionWarning)
+  "Core.IntervalError" -> Just $ TypeId "Core.IntervalError" (Proxy :: Proxy C.IntervalError)
   "Core.Transaction" -> Just $ TypeId "Core.Transaction" (Proxy :: Proxy (C.Transaction_ext ()))
   _ -> Nothing
 
@@ -103,4 +107,8 @@ instance HasTypeId C.TransactionWarning where
 
 instance HasTypeId (C.Transaction_ext ()) where
   getTypeId _ = TypeId "Core.Transaction" (Proxy :: Proxy (C.Transaction_ext ()))
+
+instance HasTypeId C.IntervalError where
+  getTypeId _ = TypeId "Core.IntervalError" (Proxy :: Proxy C.IntervalError)
+
 


### PR DESCRIPTION
This PR adds `Gen`/`GenT` instances for all the types covered in the serialization specification, inspired by the [Arbitrary instances from marlowe-cardano](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe-test/src/Spec/Marlowe/Semantics/Arbitrary.hs), and the corresponding roundtrip test.