### PR TITLE
SCP-4901 - Add eval value test

### DIFF
--- a/marlowe-spec-test/README.md
+++ b/marlowe-spec-test/README.md
@@ -113,6 +113,7 @@ The possible requests are:
 * Generate random value
 * Compute transaction
 * Play trace
+* Eval value
 
 All responses are wrapped to provide some common cases
 
@@ -267,4 +268,37 @@ The request is encoded as
 
 The payload of the `request-response` is a serialized `TransactionOutput`
 
+### Eval Value
 
+The request is encoded as
+
+```json
+{
+    "request": "eval-value",
+    "environment": <Environment serialized>,
+    "state": <State serialized>,
+    "value": <Value serialized>
+}
+```
+
+The payload of the `request-response` is an integer
+
+
+#### Example
+For example, for this request
+
+```json
+{
+    "request": "evalValue",
+    "environment": {"timeInterval": [10, 20] },
+    "state": { "accounts": [], "boundValues": [], "choices": [], "minTime": 5},
+    "value": "time_interval_start"
+}
+```
+a valid response could be
+
+```json
+{
+  "request-response": 10
+}
+```

--- a/marlowe-spec-test/marlowe-spec-test.cabal
+++ b/marlowe-spec-test/marlowe-spec-test.cabal
@@ -35,11 +35,13 @@ library
         Marlowe.Spec.Core.Arbitrary
         Marlowe.Spec.Core.Examples
         Marlowe.Spec.Core.Examples.Swap
+        Marlowe.Spec.Core.Semantics
         Marlowe.Spec.Core.Serialization.Json
         Marlowe.Spec.Interpret
         Marlowe.Spec.LocalInterpret
         Marlowe.Spec.Reproducible
         Marlowe.Spec.TypeId
+        Marlowe.Utils
     build-depends:
         aeson,
         base >=4.9 && <5,

--- a/marlowe-spec-test/src/Marlowe/Spec/Core.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/Core.hs
@@ -5,10 +5,12 @@ module Marlowe.Spec.Core (tests) where
 import Test.Tasty (TestTree, testGroup)
 import qualified Marlowe.Spec.Core.Examples
 import qualified Marlowe.Spec.Core.Serialization.Json
+import qualified Marlowe.Spec.Core.Semantics
 import Marlowe.Spec.Interpret (InterpretJsonRequest)
 
 tests :: InterpretJsonRequest -> TestTree
 tests i = testGroup "Core"
   [ Marlowe.Spec.Core.Serialization.Json.tests i
+  , Marlowe.Spec.Core.Semantics.tests i
   , Marlowe.Spec.Core.Examples.tests i
   ]

--- a/marlowe-spec-test/src/Marlowe/Spec/Core/Arbitrary.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/Core/Arbitrary.hs
@@ -18,7 +18,7 @@ import qualified Arith
 import Control.Monad (liftM2)
 import QuickCheck.GenT (vectorOf, GenT, MonadGen (..), suchThat, frequency, sized, resize, scale)
 import Semantics (Transaction_ext(..), Payment(..), TransactionWarning (..), TransactionError (..), TransactionOutput(..), TransactionOutputRecord_ext (..))
-import SemanticsTypes (Token(..), Party, Payee(..), ChoiceId (ChoiceId), Bound(..), Value(..), ValueId(..), Observation(..), Action (..), Case(..), Contract (..), Input (..), State_ext(..), IntervalError (..))
+import SemanticsTypes (Token(..), Party, Payee(..), ChoiceId (ChoiceId), Bound(..), Value(..), ValueId(..), Observation(..), Action (..), Case(..), Contract (..), Input (..), State_ext(..), IntervalError (..), Environment_ext (..))
 import SemanticsGuarantees (valid_state)
 import Test.QuickCheck (Gen, chooseInt, getSize)
 import Test.QuickCheck.Arbitrary (Arbitrary(..))
@@ -173,6 +173,12 @@ genBound = do
   lower <- arbitraryInteger
   extent <- arbitraryNonnegativeInteger
   pure $ Bound lower (lower + extent)
+
+genInterval :: Gen (Arith.Int, Arith.Int)
+genInterval = do
+  lower <- arbitraryNonnegativeInteger
+  extent <- arbitraryNonnegativeInteger
+  pure (lower, lower + extent)
 
 genValue :: InterpretJsonRequest -> GenT IO Value
 genValue i = sized (
@@ -369,3 +375,6 @@ genTransactionOutput i =
               pure $ TransactionOutput $ TransactionOutputRecord_ext warnings payments state contract ()
       )
     ]
+
+genEnvironment :: Gen (Environment_ext ())
+genEnvironment = Environment_ext <$> genInterval <*> pure ()

--- a/marlowe-spec-test/src/Marlowe/Spec/Core/Semantics.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/Core/Semantics.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BlockArguments #-}
+
+module Marlowe.Spec.Core.Semantics where
+import Test.Tasty (TestTree, testGroup)
+import Marlowe.Spec.Interpret (InterpretJsonRequest, Request (..), Response (..))
+import Test.QuickCheck.Monadic (run)
+import Marlowe.Spec.Core.Arbitrary (genValue, genState, genEnvironment)
+import Semantics (evalValue)
+import Data.Aeson (ToJSON(..))
+import qualified Data.Aeson as JSON
+import Marlowe.Spec.Reproducible (reproducibleProperty', generate, generateT, assertResponse)
+import Test.QuickCheck (withMaxSuccess)
+
+tests :: InterpretJsonRequest -> TestTree
+tests i = testGroup "Semantics"
+    [ evalValueTest i
+    ]
+
+-- The default maxSuccess is 100 and this tests modifies that to 500 as it was empirically found that 10 out of 10 times
+-- an existing bug in the purescript implementation regarding division rounding was found. With the default 100 only
+-- 5 out of 10 executions of the test found the problem.
+-- As with all testing, the fact that the implementation passes this property-based test doesn't guarantee that there
+-- are no bugs, only that the selected arbitrary examples didn't find one.
+evalValueTest :: InterpretJsonRequest -> TestTree
+evalValueTest interpret = reproducibleProperty' "Eval Value" (withMaxSuccess 500) do
+    env <- run $ generate $ genEnvironment
+    state <- run $ generateT $ genState interpret
+    value <- run $ generateT $ genValue interpret
+    let
+        req :: Request JSON.Value
+        req = EvalValue env state value
+        successResponse = RequestResponse $ toJSON $ evalValue env state value
+    assertResponse interpret req successResponse
+
+

--- a/marlowe-spec-test/src/Marlowe/Spec/LocalInterpret.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/LocalInterpret.hs
@@ -6,7 +6,7 @@ module Marlowe.Spec.LocalInterpret where
 import Arith (Int(..))
 import qualified Data.Aeson as JSON
 import Marlowe.Spec.Interpret (Response(..), Request(..))
-import Semantics (playTrace, computeTransaction)
+import Semantics (playTrace, computeTransaction, evalValue)
 import Marlowe.Spec.TypeId (TypeId (..), fromTypeName)
 import Marlowe.Spec.Core.Serialization.Json
 import Data.Data (Proxy)
@@ -30,6 +30,11 @@ interpretLocal (PlayTrace t c is) =
     $ RequestResponse
     $ JSON.toJSON
     $ playTrace (Int_of_integer t) c is
+interpretLocal (EvalValue env state val) =
+  pure
+    $ RequestResponse
+    $ JSON.toJSON
+    $ evalValue env state val
 interpretLocal (ComputeTransaction t s c) =
   pure
     $ RequestResponse

--- a/marlowe-spec-test/src/Marlowe/Utils.hs
+++ b/marlowe-spec-test/src/Marlowe/Utils.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Marlowe.Utils  where
+
+import Data.Aeson (encode)
+import qualified Data.Text.Lazy as LT
+import Data.Text.Lazy.Encoding (decodeUtf8)
+import qualified Data.Aeson as JSON
+import Data.Aeson.Types (ToJSON (..))
+
+showJson :: JSON.Value -> String
+showJson = LT.unpack . decodeUtf8 . encode
+
+showAsJson :: ToJSON a => a -> String
+showAsJson = showJson . toJSON


### PR DESCRIPTION
This PR adds the new command `EvalValue` to the spec test. It basically generates random `Value`s see what the Isabelle specification thinks the result should be and compares it with the actual response of spec client.

By doing this feature a bug was found in the purescript-marlowe repository, for which rounding of `(DivValue (NegValue (Constant 2)) (Constant 20))` differs. In the specification the value is evaluated to `0` and in purescript-marlowe to `-1`.  