### PR TITLE
SCP-4908: Add the Escrow to the examples suite

### DIFF
--- a/isabelle/CodeExports/CodeExports.thy
+++ b/isabelle/CodeExports/CodeExports.thy
@@ -81,6 +81,7 @@ export_code
   dismissClaimPayments
   confirmClaimTransactions
   confirmClaimPayments
+
   swapExample
   happyPathTransactions
   happyPathPayments

--- a/isabelle/CodeExports/CodeExports.thy
+++ b/isabelle/CodeExports/CodeExports.thy
@@ -11,6 +11,7 @@ theory CodeExports
 
 imports
   Core.Semantics
+  Examples.Escrow
   Examples.Swap
   "HOL-Library.Code_Target_Numeral"
   HOL.String
@@ -45,6 +46,8 @@ text \<open>With a \<^bold>\<open>code\_identifier\<close> we hint what the name
 code_identifier
   code_module Swap \<rightharpoonup> (Haskell) Examples.Swap
 
+code_identifier
+  code_module Escrow \<rightharpoonup> (Haskell) Examples.Escrow
 
 text \<open>We export all the constants in one statement, because they don't add up, if you export two times,
 the second export will overwrite the first one.\<close>
@@ -69,6 +72,15 @@ export_code
   validAndPositive_state
 
   \<comment> \<open> Export examples to be used as oracle specificaiton tests\<close>
+  escrowExample
+  everythingIsAlrightTransactions
+  everythingIsAlrightPayments
+  confirmProblemTransactions
+  confirmProblemPayments
+  dismissClaimTransactions
+  dismissClaimPayments
+  confirmClaimTransactions
+  confirmClaimPayments
   swapExample
   happyPathTransactions
   happyPathPayments

--- a/isabelle/Doc/Specification/Examples.thy
+++ b/isabelle/Doc/Specification/Examples.thy
@@ -1,6 +1,6 @@
 (*<*)
 theory Examples
-imports Examples.Swap
+imports Examples.Escrow Examples.Swap
 begin
 (*>*)
 

--- a/isabelle/Doc/Specification/Specification.thy
+++ b/isabelle/Doc/Specification/Specification.thy
@@ -33,7 +33,7 @@ for both the intended and not intended behaviour (in the form of bugs or exploit
 text \<open>To reduce the probability of not intended behaviour, the Marlowe DSL is designed with simplicity
 in mind. Without loops, recursion, or other features that general purposes smart-contract languages
 (E.g: Plutus, Solidity) have, it is easier to make certain claims. Each Marlowe contract can be
-reasoned with a static analizer to avoid common pitfalls such as trying to Pay more money than the
+reasoned with a static analyzer to avoid common pitfalls such as trying to Pay more money than the
 available. And the \<^emph>\<open>executable semantics\<close> that dictates the logic of \<^bold>\<open>all\<close> Marlowe contracts is
 formalized with the proof-assistant Isabelle.
 \<close>

--- a/isabelle/Doc/Specification/document/root.tex
+++ b/isabelle/Doc/Specification/document/root.tex
@@ -83,8 +83,8 @@ Brian Bush
 
 \appendix
 \input{Examples.tex}
-\input{Escrow.tex}
 \input{Swap.tex}
+\input{Escrow.tex}
 \input{ByteString.tex}
 \input{OptBoundTimeInterval.tex}
 \input{CodeExports.tex}

--- a/isabelle/Doc/Specification/document/root.tex
+++ b/isabelle/Doc/Specification/document/root.tex
@@ -83,6 +83,7 @@ Brian Bush
 
 \appendix
 \input{Examples.tex}
+\input{Escrow.tex}
 \input{Swap.tex}
 \input{ByteString.tex}
 \input{OptBoundTimeInterval.tex}

--- a/isabelle/Examples/Escrow.thy
+++ b/isabelle/Examples/Escrow.thy
@@ -10,6 +10,7 @@ subsection \<open>Contract definition\<close>
 
 record EscrowArgs =
   price             :: Value
+  token             :: Token
   seller            :: Party
   buyer             :: Party
   mediator          :: Party
@@ -18,13 +19,13 @@ record EscrowArgs =
   disputeDeadline   :: Timeout
   mediationDeadline :: Timeout
 
-definition "ada = Token (BS '''') (BS '''')"
+definition "adaToken = Token (BS '''') (BS '''')"
 
 fun mediation :: "EscrowArgs \<Rightarrow> Contract" where
   "mediation args =
     When
       [ Case (Choice (ChoiceId (BS ''Dismiss claim'') (mediator args)) [Bound 0 0])
-          (Pay (buyer args) (Account (seller args)) ada (price args) Close)
+          (Pay (buyer args) (Account (seller args)) adaToken (price args) Close)
       , Case (Choice (ChoiceId (BS ''Confirm claim'') (mediator args)) [Bound 1 1]) Close
       ] (mediationDeadline args) Close"
 
@@ -40,24 +41,203 @@ fun report :: "EscrowArgs \<Rightarrow> Contract" where
     When
       [ Case (Choice (ChoiceId (BS ''Everything is alright'') (buyer args)) [Bound 0 0]) Close
       , Case (Choice (ChoiceId (BS ''Report problem'') (buyer args)) [Bound 1 1])
-          (Pay (seller args) (Account (buyer args)) ada (price args) (dispute args))
+          (Pay (seller args) (Account (buyer args)) adaToken (price args) (dispute args))
       ] (complaintDeadline args) Close"
 
 fun escrow :: "EscrowArgs \<Rightarrow> Contract" where
   "escrow args =
     When
-      [ Case (Deposit (seller args) (buyer args) ada (price args)) (report args) ]
+      [ Case (Deposit (seller args) (buyer args) adaToken (price args)) (report args) ]
       (paymentDeadline args) Close"
 
-definition "escrow_example = escrow
-  \<lparr> price = Constant 1
+definition "escrowArgs =
+  \<lparr> price = Constant 10
+  , token = adaToken
   , seller = Role (BS ''Seller'')
   , buyer = Role (BS ''Buyer'')
   , mediator = Role (BS ''Mediator'')
   , paymentDeadline = 1664812800000
-  , complaintDeadline = 1664812800000
-  , disputeDeadline = 1664812800000
-  , mediationDeadline = 1664812800000
+  , complaintDeadline = 1664816400000
+  , disputeDeadline = 1664820420000
+  , mediationDeadline = 1664824440000
   \<rparr>"
 
-value escrow_example
+definition "escrowExample = escrow escrowArgs"
+
+subsection \<open>Everything is alright.\<close>
+
+definition
+  "everythingIsAlrightTransactions =
+    [
+      \<comment> \<open>First party deposit\<close>
+      \<lparr> interval = (1664812600000, 1664812700000)
+      , inputs = [
+                  IDeposit
+                    (seller escrowArgs)
+                    (buyer escrowArgs)
+                    (token escrowArgs)
+                    10
+                 ]
+      \<rparr>
+   ,  \<lparr> interval = (1664812900000, 1664813100000)
+      , inputs = [ IChoice (ChoiceId (BS ''Everything is alright'') (buyer escrowArgs)) 0
+                 ]
+      \<rparr>
+    ]
+  "
+
+definition
+  "everythingIsAlrightPayments =
+    [ Payment (seller escrowArgs) (Party (seller escrowArgs)) (token escrowArgs) 10
+    ]
+  "
+
+proposition
+ "playTrace 0 escrowExample everythingIsAlrightTransactions = TransactionOutput txOut
+  \<Longrightarrow>
+     txOutContract txOut = Close
+     \<and> txOutPayments txOut = everythingIsAlrightPayments
+     \<and> txOutWarnings txOut = []"
+(*<*)apply (code_simp)
+     apply (auto simp add: everythingIsAlrightPayments_def escrowArgs_def adaToken_def)
+     done(*>*)
+
+subsection \<open>Confirm problem.\<close>
+
+definition
+  "confirmProblemTransactions =
+    [
+      \<comment> \<open>First party deposit\<close>
+      \<lparr> interval = (1664812600000, 1664812700000)
+      , inputs = [
+                  IDeposit
+                    (seller escrowArgs)
+                    (buyer escrowArgs)
+                    (token escrowArgs)
+                    10
+                 ]
+      \<rparr>
+   ,  \<lparr> interval = (1664812900000, 1664813100000)
+      , inputs = [ IChoice (ChoiceId (BS ''Report problem'') (buyer escrowArgs)) 1
+                 ]
+      \<rparr>
+   ,  \<lparr> interval = (1664817400000, 1664817400000)
+      , inputs = [ IChoice (ChoiceId (BS ''Confirm problem'') (seller escrowArgs)) 1
+                 ]
+      \<rparr>
+    ]
+  "
+
+definition
+  "confirmProblemPayments =
+    [ Payment (seller escrowArgs) (Account (buyer escrowArgs)) (token escrowArgs) 10
+    , Payment (buyer escrowArgs) (Party (buyer escrowArgs)) (token escrowArgs) 10
+    ]
+  "
+
+proposition
+ "playTrace 0 escrowExample confirmProblemTransactions = TransactionOutput txOut
+  \<Longrightarrow>
+     txOutContract txOut = Close
+     \<and> txOutPayments txOut = confirmProblemPayments
+     \<and> txOutWarnings txOut = []"
+(*<*)apply (code_simp)
+     apply (auto simp add: confirmProblemPayments_def escrowArgs_def adaToken_def)
+     done(*>*)
+
+subsection \<open>Dismiss claim.\<close>
+
+definition
+  "dismissClaimTransactions =
+    [
+      \<comment> \<open>First party deposit\<close>
+      \<lparr> interval = (1664812600000, 1664812700000)
+      , inputs = [
+                  IDeposit
+                    (seller escrowArgs)
+                    (buyer escrowArgs)
+                    (token escrowArgs)
+                    10
+                 ]
+      \<rparr>
+   ,  \<lparr> interval = (1664812900000, 1664813100000)
+      , inputs = [ IChoice (ChoiceId (BS ''Report problem'') (buyer escrowArgs)) 1
+                 ]
+      \<rparr>
+   ,  \<lparr> interval = (1664817400000, 1664817400000)
+      , inputs = [ IChoice (ChoiceId (BS ''Dispute problem'') (seller escrowArgs)) 0
+                 ]
+      \<rparr>
+   ,  \<lparr> interval = (1664821400000, 1664822400000)
+      , inputs = [ IChoice (ChoiceId (BS ''Dismiss claim'') (mediator escrowArgs)) 0
+                 ]
+      \<rparr>
+    ]
+  "
+
+definition
+  "dismissClaimPayments =
+    [ Payment (seller escrowArgs) (Account (buyer escrowArgs)) (token escrowArgs) 10
+    , Payment (buyer escrowArgs) (Account (seller escrowArgs)) (token escrowArgs) 10
+    , Payment (seller escrowArgs) (Party (seller escrowArgs)) (token escrowArgs) 10
+    ]
+  "
+
+proposition
+ "playTrace 0 escrowExample dismissClaimTransactions = TransactionOutput txOut
+  \<Longrightarrow>
+     txOutContract txOut = Close
+     \<and> txOutPayments txOut = dismissClaimPayments
+     \<and> txOutWarnings txOut = []"
+(*<*)apply (code_simp)
+     apply (auto simp add: dismissClaimPayments_def escrowArgs_def adaToken_def)
+     done(*>*)
+
+subsection \<open>Confirm claim.\<close>
+
+definition
+  "confirmClaimTransactions =
+    [
+      \<comment> \<open>First party deposit\<close>
+      \<lparr> interval = (1664812600000, 1664812700000)
+      , inputs = [
+                  IDeposit
+                    (seller escrowArgs)
+                    (buyer escrowArgs)
+                    (token escrowArgs)
+                    10
+                 ]
+      \<rparr>
+   ,  \<lparr> interval = (1664812900000, 1664813100000)
+      , inputs = [ IChoice (ChoiceId (BS ''Report problem'') (buyer escrowArgs)) 1
+                 ]
+      \<rparr>
+   ,  \<lparr> interval = (1664817400000, 1664817400000)
+      , inputs = [ IChoice (ChoiceId (BS ''Dispute problem'') (seller escrowArgs)) 0
+                 ]
+      \<rparr>
+   ,  \<lparr> interval = (1664821400000, 1664822400000)
+      , inputs = [ IChoice (ChoiceId (BS ''Confirm claim'') (mediator escrowArgs)) 1
+                 ]
+      \<rparr>
+    ]
+  "
+
+definition
+  "confirmClaimPayments =
+    [ Payment (seller escrowArgs) (Account (buyer escrowArgs)) (token escrowArgs) 10
+    , Payment (buyer escrowArgs) (Party (buyer escrowArgs)) (token escrowArgs) 10
+    ]
+  "
+
+proposition
+ "playTrace 0 escrowExample confirmClaimTransactions = TransactionOutput txOut
+  \<Longrightarrow>
+     txOutContract txOut = Close
+     \<and> txOutPayments txOut = confirmClaimPayments
+     \<and> txOutWarnings txOut = []"
+(*<*)apply (code_simp)
+     apply (auto simp add: confirmClaimPayments_def escrowArgs_def adaToken_def)
+     done(*>*)
+
+end

--- a/isabelle/Examples/Escrow.thy
+++ b/isabelle/Examples/Escrow.thy
@@ -9,7 +9,7 @@ The buyer may complain that there is a problem, asking for a refund.
 If the seller disputes that complaint, then a mediator decides.
 \<close>
 subsection \<open>Contract definition\<close>
-text \<open>In the escrow contract there are the following roles:\<close>
+text \<open>The participants of the contract are:\<close>
 definition "seller = Role (BS ''Seller'')"
 definition "buyer = Role (BS ''Buyer'')"
 definition "mediator = Role (BS ''Mediator'')"

--- a/isabelle/Examples/Escrow.thy
+++ b/isabelle/Examples/Escrow.thy
@@ -1,0 +1,63 @@
+(*<*)
+theory Escrow
+  imports Core.Semantics Core.TransactionBound Core.Timeout
+begin
+(*>*)
+
+section \<open>Escrow contract\<close>
+
+subsection \<open>Contract definition\<close>
+
+record EscrowArgs =
+  price             :: Value
+  seller            :: Party
+  buyer             :: Party
+  mediator          :: Party
+  paymentDeadline   :: Timeout
+  complaintDeadline :: Timeout
+  disputeDeadline   :: Timeout
+  mediationDeadline :: Timeout
+
+definition "ada = Token (BS '''') (BS '''')"
+
+fun mediation :: "EscrowArgs \<Rightarrow> Contract" where
+  "mediation args =
+    When
+      [ Case (Choice (ChoiceId (BS ''Dismiss claim'') (mediator args)) [Bound 0 0])
+          (Pay (buyer args) (Account (seller args)) ada (price args) Close)
+      , Case (Choice (ChoiceId (BS ''Confirm claim'') (mediator args)) [Bound 1 1]) Close
+      ] (mediationDeadline args) Close"
+
+fun dispute :: "EscrowArgs \<Rightarrow> Contract" where
+  "dispute args =
+    When
+      [ Case (Choice (ChoiceId (BS ''Confirm problem'') (seller args)) [Bound 1 1]) Close
+      , Case (Choice (ChoiceId (BS ''Dispute problem'') (seller args)) [Bound 0 0]) (mediation args)
+      ] (disputeDeadline args) Close"
+
+fun report :: "EscrowArgs \<Rightarrow> Contract" where
+  "report args =
+    When
+      [ Case (Choice (ChoiceId (BS ''Everything is alright'') (buyer args)) [Bound 0 0]) Close
+      , Case (Choice (ChoiceId (BS ''Report problem'') (buyer args)) [Bound 1 1])
+          (Pay (seller args) (Account (buyer args)) ada (price args) (dispute args))
+      ] (complaintDeadline args) Close"
+
+fun escrow :: "EscrowArgs \<Rightarrow> Contract" where
+  "escrow args =
+    When
+      [ Case (Deposit (seller args) (buyer args) ada (price args)) (report args) ]
+      (paymentDeadline args) Close"
+
+definition "escrow_example = escrow
+  \<lparr> price = Constant 1
+  , seller = Role (BS ''Seller'')
+  , buyer = Role (BS ''Buyer'')
+  , mediator = Role (BS ''Mediator'')
+  , paymentDeadline = 1664812800000
+  , complaintDeadline = 1664812800000
+  , disputeDeadline = 1664812800000
+  , mediationDeadline = 1664812800000
+  \<rparr>"
+
+value escrow_example

--- a/isabelle/Examples/Escrow.thy
+++ b/isabelle/Examples/Escrow.thy
@@ -9,6 +9,14 @@ The buyer may complain that there is a problem, asking for a refund.
 If the seller disputes that complaint, then a mediator decides.
 \<close>
 subsection \<open>Contract definition\<close>
+text \<open>In the escrow contract there are the following roles:\<close>
+definition "seller = Role (BS ''Seller'')"
+definition "buyer = Role (BS ''Buyer'')"
+definition "mediator = Role (BS ''Mediator'')"
+text \<open>An escrow contract takes as arguments the price, token
+and the deadlines that apply for the payment, the complaint, the dispute and
+the mediation.
+\<close>
 record EscrowArgs =
   price             :: Value
   token             :: Token
@@ -16,9 +24,12 @@ record EscrowArgs =
   complaintDeadline :: Timeout
   disputeDeadline   :: Timeout
   mediationDeadline :: Timeout
-definition "seller = Role (BS ''Seller'')"
-definition "buyer = Role (BS ''Buyer'')"
-definition "mediator = Role (BS ''Mediator'')"
+text \<open>The contract is built in multiple steps. The innermost step is the
+mediation step, where the mediator either confirms or dismisses a claim about
+a problem with the transaction. In case the mediator dismisses the claim the
+seller is paid, in case the mediator confirms the claim, the contract is closed
+and the buyer refunded implicitly:
+\<close>
 fun mediation :: "EscrowArgs \<Rightarrow> Contract" where
   "mediation args =
     When
@@ -26,12 +37,18 @@ fun mediation :: "EscrowArgs \<Rightarrow> Contract" where
           (Pay buyer (Account seller) (token args) (price args) Close)
       , Case (Choice (ChoiceId (BS ''Confirm claim'') mediator) [Bound 1 1]) Close
       ] (mediationDeadline args) Close"
+text \<open>In case a problem is reported by the buyer, the seller has to either confirm or dispute the
+problem. In case the seller confirms the problem, the buyer is refunded implicitly.
+Disputing the problem leads to the mediation step defined above.\<close>
 fun dispute :: "EscrowArgs \<Rightarrow> Contract" where
   "dispute args =
     When
       [ Case (Choice (ChoiceId (BS ''Confirm problem'') seller) [Bound 1 1]) Close
       , Case (Choice (ChoiceId (BS ''Dispute problem'') seller) [Bound 0 0]) (mediation args)
       ] (disputeDeadline args) Close"
+text \<open>The buyer can either report that everything is alright with transaction or a problem. When
+a problem is reported the funds are placed in the buyer's account and the contract continues with the
+dispute step defined above.\<close>
 fun report :: "EscrowArgs \<Rightarrow> Contract" where
   "report args =
     When
@@ -39,12 +56,14 @@ fun report :: "EscrowArgs \<Rightarrow> Contract" where
       , Case (Choice (ChoiceId (BS ''Report problem'') buyer) [Bound 1 1])
           (Pay (seller) (Account buyer) (token args) (price args) (dispute args))
       ] (complaintDeadline args) Close"
+text \<open>The escrow contract waits for the buyer to deposit and then continues with the report step
+defined above.\<close>
 fun escrow :: "EscrowArgs \<Rightarrow> Contract" where
   "escrow args =
     When
       [ Case (Deposit seller buyer (token args) (price args)) (report args) ]
       (paymentDeadline args) Close"
-subsection \<open>Example Escrow Contract\<close>
+(*<*)
 definition "exampleArgs =
   \<lparr> price = Constant 10
   , token = Token (BS '''') (BS '''')
@@ -54,8 +73,19 @@ definition "exampleArgs =
   , mediationDeadline = 1664824440000
   \<rparr>"
 definition "escrowExample = escrow exampleArgs"
+(*>*)
 subsection \<open>Possible Outcomes\<close>
-subsubsection \<open>Everything is alright.\<close>
+text \<open>There are four possible outcomes for the escrow contract.\<close>
+subsubsection \<open>Everything is alright\<close>
+text \<open>
+Steps:
+\begin{enumerate}
+\item Buyer deposits funds into seller's account.
+\item Buyer reports that everything is alright.
+\end{enumerate}
+Outcome: Seller receives purchase price.
+\<close>
+(*<*)
 definition
   "everythingIsAlrightTransactions =
     [
@@ -78,11 +108,22 @@ proposition
      txOutContract txOut = Close
      \<and> txOutPayments txOut = everythingIsAlrightPayments
      \<and> txOutWarnings txOut = []"
-(*<*)apply (code_simp)
+     apply (code_simp)
      apply (auto simp add: everythingIsAlrightPayments_def
               seller_def buyer_def exampleArgs_def)
-     done(*>*)
-subsubsection \<open>Confirm problem.\<close>
+     done
+(*>*)
+subsubsection \<open>Confirm problem\<close>
+text \<open>
+Steps:
+\begin{enumerate}
+\item Buyer deposits funds into seller's account.
+\item Buyer reports that there is a problem.
+\item Seller confirms that there is a problem.
+\end{enumerate}
+Outcome: Buyer receives refund.
+\<close>
+(*<*)
 definition
   "confirmProblemTransactions =
     [
@@ -110,11 +151,22 @@ proposition
      txOutContract txOut = Close
      \<and> txOutPayments txOut = confirmProblemPayments
      \<and> txOutWarnings txOut = []"
-(*<*)apply (code_simp)
+     apply (code_simp)
      apply (auto simp add: confirmProblemPayments_def
               seller_def buyer_def mediator_def exampleArgs_def)
-     done(*>*)
-subsubsection \<open>Dismiss claim.\<close>
+     done
+(*>*)
+subsubsection \<open>Dismiss claim\<close>
+text \<open>
+\begin{enumerate}
+\item Buyer deposits funds into seller's account.
+\item Buyer reports that there is a problem.
+\item Seller disputes that there is a problem.
+\item Mediator dismisses the buyer's claim.
+\end{enumerate}
+Outcome: Seller receives purchase price.
+\<close>
+(*<*)
 definition
   "dismissClaimTransactions =
     [
@@ -146,11 +198,22 @@ proposition
      txOutContract txOut = Close
      \<and> txOutPayments txOut = dismissClaimPayments
      \<and> txOutWarnings txOut = []"
-(*<*)apply (code_simp)
+     apply (code_simp)
      apply (auto simp add: dismissClaimPayments_def
               seller_def buyer_def mediator_def exampleArgs_def)
-     done(*>*)
-subsubsection \<open>Confirm claim.\<close>
+     done
+(*>*)
+subsubsection \<open>Confirm claim\<close>
+text \<open>
+\begin{enumerate}
+\item Buyer deposits funds into seller's account.
+\item Buyer reports that there is a problem.
+\item Seller disputes that there is a problem.
+\item Mediator confirms the buyer's claim.
+\end{enumerate}
+Outcome: Buyer receives refund.
+\<close>
+(*<*)
 definition
   "confirmClaimTransactions =
     [
@@ -181,8 +244,9 @@ proposition
      txOutContract txOut = Close
      \<and> txOutPayments txOut = confirmClaimPayments
      \<and> txOutWarnings txOut = []"
-(*<*)apply (code_simp)
+     apply (code_simp)
      apply (auto simp add: confirmClaimPayments_def
               seller_def buyer_def mediator_def exampleArgs_def)
-     done(*>*)
+     done
 end
+(*>*)

--- a/isabelle/Examples/Escrow.thy
+++ b/isabelle/Examples/Escrow.thy
@@ -4,9 +4,8 @@ theory Escrow
 begin
 (*>*)
 section \<open>Escrow contract\<close>
-text \<open>An escrow contract is for the purchase of an item at a price.
-The buyer may complain that there is a problem, asking for a refund.
-If the seller disputes that complaint, then a mediator decides.
+text \<open>An escrow contract allows a \<^bold>\<open>Buyer\<close> to purchase an item for a price.
+The money is deposited in an escrow, waiting for some feedback from the  \<^bold>\<open>Buyer\<close>. If the  \<^bold>\<open>Buyer\<close> and  \<^bold>\<open>Seller\<close> don't agree, a  \<^bold>\<open>Mediator\<close> will resolve the conflict.
 \<close>
 subsection \<open>Contract definition\<close>
 text \<open>The participants of the contract are:\<close>

--- a/isabelle/ROOT
+++ b/isabelle/ROOT
@@ -53,6 +53,7 @@ session Examples in "Examples" = HOL +
     "HOL-Library"
     "Core"
   theories
+    Escrow
     Swap
 
 session CodeExports in "CodeExports" = HOL +
@@ -100,6 +101,7 @@ session Specification in "Doc/Specification" = HOL +
     "Core.OptBoundTimeInterval"
     "CodeExports.CodeExports"
     "Util.ByteString"
+    "Examples.Escrow"
     "Examples.Swap"
   document_files
     "root.tex"

--- a/isabelle/generated/Examples/Escrow.hs
+++ b/isabelle/generated/Examples/Escrow.hs
@@ -1,0 +1,564 @@
+{-# LANGUAGE EmptyDataDecls, RankNTypes, ScopedTypeVariables #-}
+
+module
+  Examples.Escrow(EscrowArgs_ext, escrowExample, confirmClaimPayments,
+                   dismissClaimPayments, confirmProblemPayments,
+                   confirmClaimTransactions, dismissClaimTransactions,
+                   confirmProblemTransactions, everythingIsAlrightPayments,
+                   everythingIsAlrightTransactions)
+  where {
+
+import Prelude ((==), (/=), (<), (<=), (>=), (>), (+), (-), (*), (/), (**),
+  (>>=), (>>), (=<<), (&&), (||), (^), (^^), (.), ($), ($!), (++), (!!), Eq,
+  error, id, return, not, fst, snd, map, filter, concat, concatMap, reverse,
+  zip, null, takeWhile, dropWhile, all, any, Integer, negate, abs, divMod,
+  String, Bool(True, False), Maybe(Nothing, Just));
+import qualified Prelude;
+import qualified Semantics;
+import qualified Stringa;
+import qualified SemanticsTypes;
+import qualified Arith;
+
+data EscrowArgs_ext a =
+  EscrowArgs_ext SemanticsTypes.Value SemanticsTypes.Token SemanticsTypes.Party
+    SemanticsTypes.Party SemanticsTypes.Party Arith.Int Arith.Int Arith.Int
+    Arith.Int a
+  deriving (Prelude.Read, Prelude.Show);
+
+paymentDeadline :: forall a. EscrowArgs_ext a -> Arith.Int;
+paymentDeadline
+  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
+    complaintDeadline disputeDeadline mediationDeadline more)
+  = paymentDeadline;
+
+seller :: forall a. EscrowArgs_ext a -> SemanticsTypes.Party;
+seller
+  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
+    complaintDeadline disputeDeadline mediationDeadline more)
+  = seller;
+
+price :: forall a. EscrowArgs_ext a -> SemanticsTypes.Value;
+price (EscrowArgs_ext price token seller buyer mediator paymentDeadline
+        complaintDeadline disputeDeadline mediationDeadline more)
+  = price;
+
+buyer :: forall a. EscrowArgs_ext a -> SemanticsTypes.Party;
+buyer (EscrowArgs_ext price token seller buyer mediator paymentDeadline
+        complaintDeadline disputeDeadline mediationDeadline more)
+  = buyer;
+
+adaToken :: SemanticsTypes.Token;
+adaToken = SemanticsTypes.Token (Stringa.implode []) (Stringa.implode []);
+
+complaintDeadline :: forall a. EscrowArgs_ext a -> Arith.Int;
+complaintDeadline
+  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
+    complaintDeadline disputeDeadline mediationDeadline more)
+  = complaintDeadline;
+
+disputeDeadline :: forall a. EscrowArgs_ext a -> Arith.Int;
+disputeDeadline
+  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
+    complaintDeadline disputeDeadline mediationDeadline more)
+  = disputeDeadline;
+
+mediationDeadline :: forall a. EscrowArgs_ext a -> Arith.Int;
+mediationDeadline
+  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
+    complaintDeadline disputeDeadline mediationDeadline more)
+  = mediationDeadline;
+
+mediator :: forall a. EscrowArgs_ext a -> SemanticsTypes.Party;
+mediator
+  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
+    complaintDeadline disputeDeadline mediationDeadline more)
+  = mediator;
+
+mediation :: EscrowArgs_ext () -> SemanticsTypes.Contract;
+mediation args =
+  SemanticsTypes.When
+    [SemanticsTypes.Case
+       (SemanticsTypes.Choice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char False False True False False False True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char True False True True False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char True True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False False False False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True False True True False True True False])
+           (mediator args))
+         [SemanticsTypes.Bound Arith.zero_int Arith.zero_int])
+       (SemanticsTypes.Pay (buyer args) (SemanticsTypes.Account (seller args))
+         adaToken (price args) SemanticsTypes.Close),
+      SemanticsTypes.Case
+        (SemanticsTypes.Choice
+          (SemanticsTypes.ChoiceId
+            (Stringa.implode
+              [Stringa.Char True True False False False False True False,
+                Stringa.Char True True True True False True True False,
+                Stringa.Char False True True True False True True False,
+                Stringa.Char False True True False False True True False,
+                Stringa.Char True False False True False True True False,
+                Stringa.Char False True False False True True True False,
+                Stringa.Char True False True True False True True False,
+                Stringa.Char False False False False False True False False,
+                Stringa.Char True True False False False True True False,
+                Stringa.Char False False True True False True True False,
+                Stringa.Char True False False False False True True False,
+                Stringa.Char True False False True False True True False,
+                Stringa.Char True False True True False True True False])
+            (mediator args))
+          [SemanticsTypes.Bound Arith.one_int Arith.one_int])
+        SemanticsTypes.Close]
+    (mediationDeadline args) SemanticsTypes.Close;
+
+dispute :: EscrowArgs_ext () -> SemanticsTypes.Contract;
+dispute args =
+  SemanticsTypes.When
+    [SemanticsTypes.Case
+       (SemanticsTypes.Choice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char True True False False False False True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True True True False True True False,
+               Stringa.Char False True True False False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True False True True False True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char True False True True False True True False])
+           (seller args))
+         [SemanticsTypes.Bound Arith.one_int Arith.one_int])
+       SemanticsTypes.Close,
+      SemanticsTypes.Case
+        (SemanticsTypes.Choice
+          (SemanticsTypes.ChoiceId
+            (Stringa.implode
+              [Stringa.Char False False True False False False True False,
+                Stringa.Char True False False True False True True False,
+                Stringa.Char True True False False True True True False,
+                Stringa.Char False False False False True True True False,
+                Stringa.Char True False True False True True True False,
+                Stringa.Char False False True False True True True False,
+                Stringa.Char True False True False False True True False,
+                Stringa.Char False False False False False True False False,
+                Stringa.Char False False False False True True True False,
+                Stringa.Char False True False False True True True False,
+                Stringa.Char True True True True False True True False,
+                Stringa.Char False True False False False True True False,
+                Stringa.Char False False True True False True True False,
+                Stringa.Char True False True False False True True False,
+                Stringa.Char True False True True False True True False])
+            (seller args))
+          [SemanticsTypes.Bound Arith.zero_int Arith.zero_int])
+        (mediation args)]
+    (disputeDeadline args) SemanticsTypes.Close;
+
+report :: EscrowArgs_ext () -> SemanticsTypes.Contract;
+report args =
+  SemanticsTypes.When
+    [SemanticsTypes.Case
+       (SemanticsTypes.Choice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char True False True False False False True False,
+               Stringa.Char False True True False True True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True False False True True True True False,
+               Stringa.Char False False True False True True True False,
+               Stringa.Char False False False True False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char False True True True False True True False,
+               Stringa.Char True True True False False True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char True False False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True True False False True True False,
+               Stringa.Char False False False True False True True False,
+               Stringa.Char False False True False True True True False])
+           (buyer args))
+         [SemanticsTypes.Bound Arith.zero_int Arith.zero_int])
+       SemanticsTypes.Close,
+      SemanticsTypes.Case
+        (SemanticsTypes.Choice
+          (SemanticsTypes.ChoiceId
+            (Stringa.implode
+              [Stringa.Char False True False False True False True False,
+                Stringa.Char True False True False False True True False,
+                Stringa.Char False False False False True True True False,
+                Stringa.Char True True True True False True True False,
+                Stringa.Char False True False False True True True False,
+                Stringa.Char False False True False True True True False,
+                Stringa.Char False False False False False True False False,
+                Stringa.Char False False False False True True True False,
+                Stringa.Char False True False False True True True False,
+                Stringa.Char True True True True False True True False,
+                Stringa.Char False True False False False True True False,
+                Stringa.Char False False True True False True True False,
+                Stringa.Char True False True False False True True False,
+                Stringa.Char True False True True False True True False])
+            (buyer args))
+          [SemanticsTypes.Bound Arith.one_int Arith.one_int])
+        (SemanticsTypes.Pay (seller args) (SemanticsTypes.Account (buyer args))
+          adaToken (price args) (dispute args))]
+    (complaintDeadline args) SemanticsTypes.Close;
+
+escrow :: EscrowArgs_ext () -> SemanticsTypes.Contract;
+escrow args =
+  SemanticsTypes.When
+    [SemanticsTypes.Case
+       (SemanticsTypes.Deposit (seller args) (buyer args) adaToken (price args))
+       (report args)]
+    (paymentDeadline args) SemanticsTypes.Close;
+
+escrowArgs :: EscrowArgs_ext ();
+escrowArgs =
+  EscrowArgs_ext
+    (SemanticsTypes.Constant (Arith.Int_of_integer (10 :: Integer))) adaToken
+    (SemanticsTypes.Role
+      (Stringa.implode
+        [Stringa.Char True True False False True False True False,
+          Stringa.Char True False True False False True True False,
+          Stringa.Char False False True True False True True False,
+          Stringa.Char False False True True False True True False,
+          Stringa.Char True False True False False True True False,
+          Stringa.Char False True False False True True True False]))
+    (SemanticsTypes.Role
+      (Stringa.implode
+        [Stringa.Char False True False False False False True False,
+          Stringa.Char True False True False True True True False,
+          Stringa.Char True False False True True True True False,
+          Stringa.Char True False True False False True True False,
+          Stringa.Char False True False False True True True False]))
+    (SemanticsTypes.Role
+      (Stringa.implode
+        [Stringa.Char True False True True False False True False,
+          Stringa.Char True False True False False True True False,
+          Stringa.Char False False True False False True True False,
+          Stringa.Char True False False True False True True False,
+          Stringa.Char True False False False False True True False,
+          Stringa.Char False False True False True True True False,
+          Stringa.Char True True True True False True True False,
+          Stringa.Char False True False False True True True False]))
+    (Arith.Int_of_integer (1664812800000 :: Integer))
+    (Arith.Int_of_integer (1664816400000 :: Integer))
+    (Arith.Int_of_integer (1664820420000 :: Integer))
+    (Arith.Int_of_integer (1664824440000 :: Integer)) ();
+
+escrowExample :: SemanticsTypes.Contract;
+escrowExample = escrow escrowArgs;
+
+token :: forall a. EscrowArgs_ext a -> SemanticsTypes.Token;
+token (EscrowArgs_ext price token seller buyer mediator paymentDeadline
+        complaintDeadline disputeDeadline mediationDeadline more)
+  = token;
+
+confirmClaimPayments :: [Semantics.Payment];
+confirmClaimPayments =
+  [Semantics.Payment (seller escrowArgs)
+     (SemanticsTypes.Account (buyer escrowArgs)) (token escrowArgs)
+     (Arith.Int_of_integer (10 :: Integer)),
+    Semantics.Payment (buyer escrowArgs)
+      (SemanticsTypes.Party (buyer escrowArgs)) (token escrowArgs)
+      (Arith.Int_of_integer (10 :: Integer))];
+
+dismissClaimPayments :: [Semantics.Payment];
+dismissClaimPayments =
+  [Semantics.Payment (seller escrowArgs)
+     (SemanticsTypes.Account (buyer escrowArgs)) (token escrowArgs)
+     (Arith.Int_of_integer (10 :: Integer)),
+    Semantics.Payment (buyer escrowArgs)
+      (SemanticsTypes.Account (seller escrowArgs)) (token escrowArgs)
+      (Arith.Int_of_integer (10 :: Integer)),
+    Semantics.Payment (seller escrowArgs)
+      (SemanticsTypes.Party (seller escrowArgs)) (token escrowArgs)
+      (Arith.Int_of_integer (10 :: Integer))];
+
+confirmProblemPayments :: [Semantics.Payment];
+confirmProblemPayments =
+  [Semantics.Payment (seller escrowArgs)
+     (SemanticsTypes.Account (buyer escrowArgs)) (token escrowArgs)
+     (Arith.Int_of_integer (10 :: Integer)),
+    Semantics.Payment (buyer escrowArgs)
+      (SemanticsTypes.Party (buyer escrowArgs)) (token escrowArgs)
+      (Arith.Int_of_integer (10 :: Integer))];
+
+confirmClaimTransactions :: [Semantics.Transaction_ext ()];
+confirmClaimTransactions =
+  [Semantics.Transaction_ext
+     (Arith.Int_of_integer (1664812600000 :: Integer),
+       Arith.Int_of_integer (1664812700000 :: Integer))
+     [SemanticsTypes.IDeposit (seller escrowArgs) (buyer escrowArgs)
+        (token escrowArgs) (Arith.Int_of_integer (10 :: Integer))]
+     (),
+    Semantics.Transaction_ext
+      (Arith.Int_of_integer (1664812900000 :: Integer),
+        Arith.Int_of_integer (1664813100000 :: Integer))
+      [SemanticsTypes.IChoice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char False True False False True False True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char False False True False True True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char True False True True False True True False])
+           (buyer escrowArgs))
+         Arith.one_int]
+      (),
+    Semantics.Transaction_ext
+      (Arith.Int_of_integer (1664817400000 :: Integer),
+        Arith.Int_of_integer (1664817400000 :: Integer))
+      [SemanticsTypes.IChoice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char False False True False False False True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char True False True False True True True False,
+               Stringa.Char False False True False True True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char True False True True False True True False])
+           (seller escrowArgs))
+         Arith.zero_int]
+      (),
+    Semantics.Transaction_ext
+      (Arith.Int_of_integer (1664821400000 :: Integer),
+        Arith.Int_of_integer (1664822400000 :: Integer))
+      [SemanticsTypes.IChoice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char True True False False False False True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True True True False True True False,
+               Stringa.Char False True True False False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True False True True False True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char True True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False False False False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True False True True False True True False])
+           (mediator escrowArgs))
+         Arith.one_int]
+      ()];
+
+dismissClaimTransactions :: [Semantics.Transaction_ext ()];
+dismissClaimTransactions =
+  [Semantics.Transaction_ext
+     (Arith.Int_of_integer (1664812600000 :: Integer),
+       Arith.Int_of_integer (1664812700000 :: Integer))
+     [SemanticsTypes.IDeposit (seller escrowArgs) (buyer escrowArgs)
+        (token escrowArgs) (Arith.Int_of_integer (10 :: Integer))]
+     (),
+    Semantics.Transaction_ext
+      (Arith.Int_of_integer (1664812900000 :: Integer),
+        Arith.Int_of_integer (1664813100000 :: Integer))
+      [SemanticsTypes.IChoice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char False True False False True False True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char False False True False True True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char True False True True False True True False])
+           (buyer escrowArgs))
+         Arith.one_int]
+      (),
+    Semantics.Transaction_ext
+      (Arith.Int_of_integer (1664817400000 :: Integer),
+        Arith.Int_of_integer (1664817400000 :: Integer))
+      [SemanticsTypes.IChoice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char False False True False False False True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char True False True False True True True False,
+               Stringa.Char False False True False True True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char True False True True False True True False])
+           (seller escrowArgs))
+         Arith.zero_int]
+      (),
+    Semantics.Transaction_ext
+      (Arith.Int_of_integer (1664821400000 :: Integer),
+        Arith.Int_of_integer (1664822400000 :: Integer))
+      [SemanticsTypes.IChoice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char False False True False False False True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char True False True True False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char True True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False False False False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True False True True False True True False])
+           (mediator escrowArgs))
+         Arith.zero_int]
+      ()];
+
+confirmProblemTransactions :: [Semantics.Transaction_ext ()];
+confirmProblemTransactions =
+  [Semantics.Transaction_ext
+     (Arith.Int_of_integer (1664812600000 :: Integer),
+       Arith.Int_of_integer (1664812700000 :: Integer))
+     [SemanticsTypes.IDeposit (seller escrowArgs) (buyer escrowArgs)
+        (token escrowArgs) (Arith.Int_of_integer (10 :: Integer))]
+     (),
+    Semantics.Transaction_ext
+      (Arith.Int_of_integer (1664812900000 :: Integer),
+        Arith.Int_of_integer (1664813100000 :: Integer))
+      [SemanticsTypes.IChoice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char False True False False True False True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char False False True False True True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char True False True True False True True False])
+           (buyer escrowArgs))
+         Arith.one_int]
+      (),
+    Semantics.Transaction_ext
+      (Arith.Int_of_integer (1664817400000 :: Integer),
+        Arith.Int_of_integer (1664817400000 :: Integer))
+      [SemanticsTypes.IChoice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char True True False False False False True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True True True False True True False,
+               Stringa.Char False True True False False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True False True True False True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char False False False False True True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True True True True False True True False,
+               Stringa.Char False True False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char True False True True False True True False])
+           (seller escrowArgs))
+         Arith.one_int]
+      ()];
+
+everythingIsAlrightPayments :: [Semantics.Payment];
+everythingIsAlrightPayments =
+  [Semantics.Payment (seller escrowArgs)
+     (SemanticsTypes.Party (seller escrowArgs)) (token escrowArgs)
+     (Arith.Int_of_integer (10 :: Integer))];
+
+everythingIsAlrightTransactions :: [Semantics.Transaction_ext ()];
+everythingIsAlrightTransactions =
+  [Semantics.Transaction_ext
+     (Arith.Int_of_integer (1664812600000 :: Integer),
+       Arith.Int_of_integer (1664812700000 :: Integer))
+     [SemanticsTypes.IDeposit (seller escrowArgs) (buyer escrowArgs)
+        (token escrowArgs) (Arith.Int_of_integer (10 :: Integer))]
+     (),
+    Semantics.Transaction_ext
+      (Arith.Int_of_integer (1664812900000 :: Integer),
+        Arith.Int_of_integer (1664813100000 :: Integer))
+      [SemanticsTypes.IChoice
+         (SemanticsTypes.ChoiceId
+           (Stringa.implode
+             [Stringa.Char True False True False False False True False,
+               Stringa.Char False True True False True True True False,
+               Stringa.Char True False True False False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True False False True True True True False,
+               Stringa.Char False False True False True True True False,
+               Stringa.Char False False False True False True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char False True True True False True True False,
+               Stringa.Char True True True False False True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True False False True True True False,
+               Stringa.Char False False False False False True False False,
+               Stringa.Char True False False False False True True False,
+               Stringa.Char False False True True False True True False,
+               Stringa.Char False True False False True True True False,
+               Stringa.Char True False False True False True True False,
+               Stringa.Char True True True False False True True False,
+               Stringa.Char False False False True False True True False,
+               Stringa.Char False False True False True True True False])
+           (buyer escrowArgs))
+         Arith.zero_int]
+      ()];
+
+}

--- a/isabelle/generated/Examples/Escrow.hs
+++ b/isabelle/generated/Examples/Escrow.hs
@@ -20,59 +20,77 @@ import qualified SemanticsTypes;
 import qualified Arith;
 
 data EscrowArgs_ext a =
-  EscrowArgs_ext SemanticsTypes.Value SemanticsTypes.Token SemanticsTypes.Party
-    SemanticsTypes.Party SemanticsTypes.Party Arith.Int Arith.Int Arith.Int
-    Arith.Int a
+  EscrowArgs_ext SemanticsTypes.Value SemanticsTypes.Token Arith.Int Arith.Int
+    Arith.Int Arith.Int a
   deriving (Prelude.Read, Prelude.Show);
+
+buyer :: SemanticsTypes.Party;
+buyer =
+  SemanticsTypes.Role
+    (Stringa.implode
+      [Stringa.Char False True False False False False True False,
+        Stringa.Char True False True False True True True False,
+        Stringa.Char True False False True True True True False,
+        Stringa.Char True False True False False True True False,
+        Stringa.Char False True False False True True True False]);
 
 paymentDeadline :: forall a. EscrowArgs_ext a -> Arith.Int;
 paymentDeadline
-  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
-    complaintDeadline disputeDeadline mediationDeadline more)
+  (EscrowArgs_ext price token paymentDeadline complaintDeadline disputeDeadline
+    mediationDeadline more)
   = paymentDeadline;
 
-seller :: forall a. EscrowArgs_ext a -> SemanticsTypes.Party;
-seller
-  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
-    complaintDeadline disputeDeadline mediationDeadline more)
-  = seller;
+token :: forall a. EscrowArgs_ext a -> SemanticsTypes.Token;
+token (EscrowArgs_ext price token paymentDeadline complaintDeadline
+        disputeDeadline mediationDeadline more)
+  = token;
 
 price :: forall a. EscrowArgs_ext a -> SemanticsTypes.Value;
-price (EscrowArgs_ext price token seller buyer mediator paymentDeadline
-        complaintDeadline disputeDeadline mediationDeadline more)
+price (EscrowArgs_ext price token paymentDeadline complaintDeadline
+        disputeDeadline mediationDeadline more)
   = price;
 
-buyer :: forall a. EscrowArgs_ext a -> SemanticsTypes.Party;
-buyer (EscrowArgs_ext price token seller buyer mediator paymentDeadline
-        complaintDeadline disputeDeadline mediationDeadline more)
-  = buyer;
-
-adaToken :: SemanticsTypes.Token;
-adaToken = SemanticsTypes.Token (Stringa.implode []) (Stringa.implode []);
+seller :: SemanticsTypes.Party;
+seller =
+  SemanticsTypes.Role
+    (Stringa.implode
+      [Stringa.Char True True False False True False True False,
+        Stringa.Char True False True False False True True False,
+        Stringa.Char False False True True False True True False,
+        Stringa.Char False False True True False True True False,
+        Stringa.Char True False True False False True True False,
+        Stringa.Char False True False False True True True False]);
 
 complaintDeadline :: forall a. EscrowArgs_ext a -> Arith.Int;
 complaintDeadline
-  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
-    complaintDeadline disputeDeadline mediationDeadline more)
+  (EscrowArgs_ext price token paymentDeadline complaintDeadline disputeDeadline
+    mediationDeadline more)
   = complaintDeadline;
 
 disputeDeadline :: forall a. EscrowArgs_ext a -> Arith.Int;
 disputeDeadline
-  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
-    complaintDeadline disputeDeadline mediationDeadline more)
+  (EscrowArgs_ext price token paymentDeadline complaintDeadline disputeDeadline
+    mediationDeadline more)
   = disputeDeadline;
 
 mediationDeadline :: forall a. EscrowArgs_ext a -> Arith.Int;
 mediationDeadline
-  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
-    complaintDeadline disputeDeadline mediationDeadline more)
+  (EscrowArgs_ext price token paymentDeadline complaintDeadline disputeDeadline
+    mediationDeadline more)
   = mediationDeadline;
 
-mediator :: forall a. EscrowArgs_ext a -> SemanticsTypes.Party;
-mediator
-  (EscrowArgs_ext price token seller buyer mediator paymentDeadline
-    complaintDeadline disputeDeadline mediationDeadline more)
-  = mediator;
+mediator :: SemanticsTypes.Party;
+mediator =
+  SemanticsTypes.Role
+    (Stringa.implode
+      [Stringa.Char True False True True False False True False,
+        Stringa.Char True False True False False True True False,
+        Stringa.Char False False True False False True True False,
+        Stringa.Char True False False True False True True False,
+        Stringa.Char True False False False False True True False,
+        Stringa.Char False False True False True True True False,
+        Stringa.Char True True True True False True True False,
+        Stringa.Char False True False False True True True False]);
 
 mediation :: EscrowArgs_ext () -> SemanticsTypes.Contract;
 mediation args =
@@ -94,10 +112,10 @@ mediation args =
                Stringa.Char True False False False False True True False,
                Stringa.Char True False False True False True True False,
                Stringa.Char True False True True False True True False])
-           (mediator args))
+           mediator)
          [SemanticsTypes.Bound Arith.zero_int Arith.zero_int])
-       (SemanticsTypes.Pay (buyer args) (SemanticsTypes.Account (seller args))
-         adaToken (price args) SemanticsTypes.Close),
+       (SemanticsTypes.Pay buyer (SemanticsTypes.Account seller) (token args)
+         (price args) SemanticsTypes.Close),
       SemanticsTypes.Case
         (SemanticsTypes.Choice
           (SemanticsTypes.ChoiceId
@@ -115,7 +133,7 @@ mediation args =
                 Stringa.Char True False False False False True True False,
                 Stringa.Char True False False True False True True False,
                 Stringa.Char True False True True False True True False])
-            (mediator args))
+            mediator)
           [SemanticsTypes.Bound Arith.one_int Arith.one_int])
         SemanticsTypes.Close]
     (mediationDeadline args) SemanticsTypes.Close;
@@ -142,7 +160,7 @@ dispute args =
                Stringa.Char False False True True False True True False,
                Stringa.Char True False True False False True True False,
                Stringa.Char True False True True False True True False])
-           (seller args))
+           seller)
          [SemanticsTypes.Bound Arith.one_int Arith.one_int])
        SemanticsTypes.Close,
       SemanticsTypes.Case
@@ -164,7 +182,7 @@ dispute args =
                 Stringa.Char False False True True False True True False,
                 Stringa.Char True False True False False True True False,
                 Stringa.Char True False True True False True True False])
-            (seller args))
+            seller)
           [SemanticsTypes.Bound Arith.zero_int Arith.zero_int])
         (mediation args)]
     (disputeDeadline args) SemanticsTypes.Close;
@@ -197,7 +215,7 @@ report args =
                Stringa.Char True True True False False True True False,
                Stringa.Char False False False True False True True False,
                Stringa.Char False False True False True True True False])
-           (buyer args))
+           buyer)
          [SemanticsTypes.Bound Arith.zero_int Arith.zero_int])
        SemanticsTypes.Close,
       SemanticsTypes.Case
@@ -218,90 +236,54 @@ report args =
                 Stringa.Char False False True True False True True False,
                 Stringa.Char True False True False False True True False,
                 Stringa.Char True False True True False True True False])
-            (buyer args))
+            buyer)
           [SemanticsTypes.Bound Arith.one_int Arith.one_int])
-        (SemanticsTypes.Pay (seller args) (SemanticsTypes.Account (buyer args))
-          adaToken (price args) (dispute args))]
+        (SemanticsTypes.Pay seller (SemanticsTypes.Account buyer) (token args)
+          (price args) (dispute args))]
     (complaintDeadline args) SemanticsTypes.Close;
 
 escrow :: EscrowArgs_ext () -> SemanticsTypes.Contract;
 escrow args =
   SemanticsTypes.When
     [SemanticsTypes.Case
-       (SemanticsTypes.Deposit (seller args) (buyer args) adaToken (price args))
+       (SemanticsTypes.Deposit seller buyer (token args) (price args))
        (report args)]
     (paymentDeadline args) SemanticsTypes.Close;
 
-escrowArgs :: EscrowArgs_ext ();
-escrowArgs =
+exampleArgs :: EscrowArgs_ext ();
+exampleArgs =
   EscrowArgs_ext
-    (SemanticsTypes.Constant (Arith.Int_of_integer (10 :: Integer))) adaToken
-    (SemanticsTypes.Role
-      (Stringa.implode
-        [Stringa.Char True True False False True False True False,
-          Stringa.Char True False True False False True True False,
-          Stringa.Char False False True True False True True False,
-          Stringa.Char False False True True False True True False,
-          Stringa.Char True False True False False True True False,
-          Stringa.Char False True False False True True True False]))
-    (SemanticsTypes.Role
-      (Stringa.implode
-        [Stringa.Char False True False False False False True False,
-          Stringa.Char True False True False True True True False,
-          Stringa.Char True False False True True True True False,
-          Stringa.Char True False True False False True True False,
-          Stringa.Char False True False False True True True False]))
-    (SemanticsTypes.Role
-      (Stringa.implode
-        [Stringa.Char True False True True False False True False,
-          Stringa.Char True False True False False True True False,
-          Stringa.Char False False True False False True True False,
-          Stringa.Char True False False True False True True False,
-          Stringa.Char True False False False False True True False,
-          Stringa.Char False False True False True True True False,
-          Stringa.Char True True True True False True True False,
-          Stringa.Char False True False False True True True False]))
+    (SemanticsTypes.Constant (Arith.Int_of_integer (10 :: Integer)))
+    (SemanticsTypes.Token (Stringa.implode []) (Stringa.implode []))
     (Arith.Int_of_integer (1664812800000 :: Integer))
     (Arith.Int_of_integer (1664816400000 :: Integer))
     (Arith.Int_of_integer (1664820420000 :: Integer))
     (Arith.Int_of_integer (1664824440000 :: Integer)) ();
 
 escrowExample :: SemanticsTypes.Contract;
-escrowExample = escrow escrowArgs;
-
-token :: forall a. EscrowArgs_ext a -> SemanticsTypes.Token;
-token (EscrowArgs_ext price token seller buyer mediator paymentDeadline
-        complaintDeadline disputeDeadline mediationDeadline more)
-  = token;
+escrowExample = escrow exampleArgs;
 
 confirmClaimPayments :: [Semantics.Payment];
 confirmClaimPayments =
-  [Semantics.Payment (seller escrowArgs)
-     (SemanticsTypes.Account (buyer escrowArgs)) (token escrowArgs)
+  [Semantics.Payment seller (SemanticsTypes.Account buyer) (token exampleArgs)
      (Arith.Int_of_integer (10 :: Integer)),
-    Semantics.Payment (buyer escrowArgs)
-      (SemanticsTypes.Party (buyer escrowArgs)) (token escrowArgs)
+    Semantics.Payment buyer (SemanticsTypes.Party buyer) (token exampleArgs)
       (Arith.Int_of_integer (10 :: Integer))];
 
 dismissClaimPayments :: [Semantics.Payment];
 dismissClaimPayments =
-  [Semantics.Payment (seller escrowArgs)
-     (SemanticsTypes.Account (buyer escrowArgs)) (token escrowArgs)
+  [Semantics.Payment seller (SemanticsTypes.Account buyer) (token exampleArgs)
      (Arith.Int_of_integer (10 :: Integer)),
-    Semantics.Payment (buyer escrowArgs)
-      (SemanticsTypes.Account (seller escrowArgs)) (token escrowArgs)
+    Semantics.Payment buyer (SemanticsTypes.Account seller) (token exampleArgs)
       (Arith.Int_of_integer (10 :: Integer)),
-    Semantics.Payment (seller escrowArgs)
-      (SemanticsTypes.Party (seller escrowArgs)) (token escrowArgs)
+    Semantics.Payment seller (SemanticsTypes.Party seller) (token exampleArgs)
       (Arith.Int_of_integer (10 :: Integer))];
 
 confirmProblemPayments :: [Semantics.Payment];
 confirmProblemPayments =
-  [Semantics.Payment (seller escrowArgs)
-     (SemanticsTypes.Account (buyer escrowArgs)) (token escrowArgs)
+  [Semantics.Payment seller (SemanticsTypes.Account buyer) (token exampleArgs)
      (Arith.Int_of_integer (10 :: Integer)),
-    Semantics.Payment (buyer escrowArgs)
-      (SemanticsTypes.Party (buyer escrowArgs)) (token escrowArgs)
+    Semantics.Payment buyer (SemanticsTypes.Party buyer) (token exampleArgs)
       (Arith.Int_of_integer (10 :: Integer))];
 
 confirmClaimTransactions :: [Semantics.Transaction_ext ()];
@@ -309,8 +291,8 @@ confirmClaimTransactions =
   [Semantics.Transaction_ext
      (Arith.Int_of_integer (1664812600000 :: Integer),
        Arith.Int_of_integer (1664812700000 :: Integer))
-     [SemanticsTypes.IDeposit (seller escrowArgs) (buyer escrowArgs)
-        (token escrowArgs) (Arith.Int_of_integer (10 :: Integer))]
+     [SemanticsTypes.IDeposit seller buyer (token exampleArgs)
+        (Arith.Int_of_integer (10 :: Integer))]
      (),
     Semantics.Transaction_ext
       (Arith.Int_of_integer (1664812900000 :: Integer),
@@ -332,7 +314,7 @@ confirmClaimTransactions =
                Stringa.Char False False True True False True True False,
                Stringa.Char True False True False False True True False,
                Stringa.Char True False True True False True True False])
-           (buyer escrowArgs))
+           buyer)
          Arith.one_int]
       (),
     Semantics.Transaction_ext
@@ -356,7 +338,7 @@ confirmClaimTransactions =
                Stringa.Char False False True True False True True False,
                Stringa.Char True False True False False True True False,
                Stringa.Char True False True True False True True False])
-           (seller escrowArgs))
+           seller)
          Arith.zero_int]
       (),
     Semantics.Transaction_ext
@@ -378,7 +360,7 @@ confirmClaimTransactions =
                Stringa.Char True False False False False True True False,
                Stringa.Char True False False True False True True False,
                Stringa.Char True False True True False True True False])
-           (mediator escrowArgs))
+           mediator)
          Arith.one_int]
       ()];
 
@@ -387,8 +369,8 @@ dismissClaimTransactions =
   [Semantics.Transaction_ext
      (Arith.Int_of_integer (1664812600000 :: Integer),
        Arith.Int_of_integer (1664812700000 :: Integer))
-     [SemanticsTypes.IDeposit (seller escrowArgs) (buyer escrowArgs)
-        (token escrowArgs) (Arith.Int_of_integer (10 :: Integer))]
+     [SemanticsTypes.IDeposit seller buyer (token exampleArgs)
+        (Arith.Int_of_integer (10 :: Integer))]
      (),
     Semantics.Transaction_ext
       (Arith.Int_of_integer (1664812900000 :: Integer),
@@ -410,7 +392,7 @@ dismissClaimTransactions =
                Stringa.Char False False True True False True True False,
                Stringa.Char True False True False False True True False,
                Stringa.Char True False True True False True True False])
-           (buyer escrowArgs))
+           buyer)
          Arith.one_int]
       (),
     Semantics.Transaction_ext
@@ -434,7 +416,7 @@ dismissClaimTransactions =
                Stringa.Char False False True True False True True False,
                Stringa.Char True False True False False True True False,
                Stringa.Char True False True True False True True False])
-           (seller escrowArgs))
+           seller)
          Arith.zero_int]
       (),
     Semantics.Transaction_ext
@@ -456,7 +438,7 @@ dismissClaimTransactions =
                Stringa.Char True False False False False True True False,
                Stringa.Char True False False True False True True False,
                Stringa.Char True False True True False True True False])
-           (mediator escrowArgs))
+           mediator)
          Arith.zero_int]
       ()];
 
@@ -465,8 +447,8 @@ confirmProblemTransactions =
   [Semantics.Transaction_ext
      (Arith.Int_of_integer (1664812600000 :: Integer),
        Arith.Int_of_integer (1664812700000 :: Integer))
-     [SemanticsTypes.IDeposit (seller escrowArgs) (buyer escrowArgs)
-        (token escrowArgs) (Arith.Int_of_integer (10 :: Integer))]
+     [SemanticsTypes.IDeposit seller buyer (token exampleArgs)
+        (Arith.Int_of_integer (10 :: Integer))]
      (),
     Semantics.Transaction_ext
       (Arith.Int_of_integer (1664812900000 :: Integer),
@@ -488,7 +470,7 @@ confirmProblemTransactions =
                Stringa.Char False False True True False True True False,
                Stringa.Char True False True False False True True False,
                Stringa.Char True False True True False True True False])
-           (buyer escrowArgs))
+           buyer)
          Arith.one_int]
       (),
     Semantics.Transaction_ext
@@ -512,14 +494,13 @@ confirmProblemTransactions =
                Stringa.Char False False True True False True True False,
                Stringa.Char True False True False False True True False,
                Stringa.Char True False True True False True True False])
-           (seller escrowArgs))
+           seller)
          Arith.one_int]
       ()];
 
 everythingIsAlrightPayments :: [Semantics.Payment];
 everythingIsAlrightPayments =
-  [Semantics.Payment (seller escrowArgs)
-     (SemanticsTypes.Party (seller escrowArgs)) (token escrowArgs)
+  [Semantics.Payment seller (SemanticsTypes.Party seller) (token exampleArgs)
      (Arith.Int_of_integer (10 :: Integer))];
 
 everythingIsAlrightTransactions :: [Semantics.Transaction_ext ()];
@@ -527,8 +508,8 @@ everythingIsAlrightTransactions =
   [Semantics.Transaction_ext
      (Arith.Int_of_integer (1664812600000 :: Integer),
        Arith.Int_of_integer (1664812700000 :: Integer))
-     [SemanticsTypes.IDeposit (seller escrowArgs) (buyer escrowArgs)
-        (token escrowArgs) (Arith.Int_of_integer (10 :: Integer))]
+     [SemanticsTypes.IDeposit seller buyer (token exampleArgs)
+        (Arith.Int_of_integer (10 :: Integer))]
      (),
     Semantics.Transaction_ext
       (Arith.Int_of_integer (1664812900000 :: Integer),
@@ -557,7 +538,7 @@ everythingIsAlrightTransactions =
                Stringa.Char True True True False False True True False,
                Stringa.Char False False False True False True True False,
                Stringa.Char False False True False True True True False])
-           (buyer escrowArgs))
+           buyer)
          Arith.zero_int]
       ()];
 

--- a/isabelle/marlowe.cabal
+++ b/isabelle/marlowe.cabal
@@ -41,6 +41,7 @@ library
         Arith
         ArithNumInstance
         CoreOrphanEq
+        Examples.Escrow
         Examples.Swap
         MarloweCoreJson
         Semantics

--- a/marlowe-spec-test/marlowe-spec-test.cabal
+++ b/marlowe-spec-test/marlowe-spec-test.cabal
@@ -34,6 +34,7 @@ library
         Marlowe.Spec.Core
         Marlowe.Spec.Core.Arbitrary
         Marlowe.Spec.Core.Examples
+        Marlowe.Spec.Core.Examples.Escrow
         Marlowe.Spec.Core.Examples.Swap
         Marlowe.Spec.Core.Semantics
         Marlowe.Spec.Core.Serialization.Json

--- a/marlowe-spec-test/src/Marlowe/Spec/Core/Examples.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/Core/Examples.hs
@@ -2,10 +2,12 @@
 
 module Marlowe.Spec.Core.Examples (tests) where
 import Test.Tasty (TestTree, testGroup)
+import qualified Marlowe.Spec.Core.Examples.Escrow
 import qualified Marlowe.Spec.Core.Examples.Swap
 import Marlowe.Spec.Interpret (InterpretJsonRequest)
 
 tests :: InterpretJsonRequest -> TestTree
 tests i = testGroup "Contract examples"
   [ Marlowe.Spec.Core.Examples.Swap.tests i
+  , Marlowe.Spec.Core.Examples.Escrow.tests i
   ]

--- a/marlowe-spec-test/src/Marlowe/Spec/Core/Examples/Escrow.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/Core/Examples/Escrow.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Marlowe.Spec.Core.Examples.Escrow (tests) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
+import Marlowe.Spec.Interpret (InterpretJsonRequest, Request (..), parseValidResponse)
+import Semantics (TransactionOutput(..), txOutContract, txOutWarnings, txOutPayments, Transaction_ext (..), Payment (..))
+import SemanticsTypes (Contract(..))
+import Examples.Escrow (confirmProblemPayments, dismissClaimPayments, confirmClaimPayments, escrowExample, confirmClaimTransactions, dismissClaimTransactions, confirmProblemTransactions, everythingIsAlrightPayments, everythingIsAlrightTransactions)
+
+tests :: InterpretJsonRequest -> TestTree
+tests i = testGroup "Escrow"
+    [ everythingIsAlright i
+    , confirmProblem i
+    , dismissClaim i
+    , confirmClaim i
+    ]
+
+everythingIsAlright :: InterpretJsonRequest -> TestTree
+everythingIsAlright = runScenario "Everything is alright" everythingIsAlrightTransactions everythingIsAlrightPayments
+
+confirmProblem :: InterpretJsonRequest -> TestTree
+confirmProblem = runScenario "Confirm Problem" confirmProblemTransactions confirmProblemPayments
+
+dismissClaim :: InterpretJsonRequest -> TestTree
+dismissClaim = runScenario "Dismiss Claim" dismissClaimTransactions dismissClaimPayments
+
+confirmClaim :: InterpretJsonRequest -> TestTree
+confirmClaim = runScenario "Confirm Claim" confirmClaimTransactions confirmClaimPayments
+
+runScenario :: String -> [Transaction_ext ()] -> [Payment] -> InterpretJsonRequest -> TestTree
+runScenario name transactions payments interpret = testCase name
+    ( do
+        res <- interpret $ PlayTrace 0 escrowExample transactions
+        case parseValidResponse res of
+            Left err -> assertFailure err
+            Right (TransactionError err) -> assertFailure $ "Transaction error: " ++ show err
+            Right (TransactionOutput o) -> do
+              txOutContract o @?= Close
+              txOutWarnings o @?= []
+              txOutPayments o @?= payments
+    )


### PR DESCRIPTION
This PR adds 
- the Escrow example to Isabelle
- and the generated specification
- Unit tests for all possible outcomes of the contract to the test-spec