### PR TITLE
SCP-4869 - Add lemma and test around rounding to zero

### DIFF
--- a/isabelle/Core/Semantics.thy
+++ b/isabelle/Core/Semantics.thy
@@ -109,6 +109,13 @@ lemma evalDivByItSelf : "a \<noteq> 0 \<Longrightarrow> evalValue env sta x = a 
 lemma evalDivByOneIsX : "evalValue env sta y = 1 \<Longrightarrow> evalValue env sta (DivValue x y) = evalValue env sta x"
   by (simp add:Let_def)
 
+
+lemma evalDivRoundToZero :
+  assumes "\<bar>(evalValue env sta n)\<bar> < \<bar>(evalValue env sta d)\<bar>"
+  shows "evalValue env sta (DivValue n d) = 0" 
+  using assms 
+  by (auto simp add: Let_def)
+
 lemma quotMultiplyEquivalence : "c \<noteq> 0 \<Longrightarrow> (c * a) quot (c * b) = a quot b"
   apply auto
   apply (simp_all add: mult_less_0_iff)

--- a/isabelle/Doc/Specification/Core.thy
+++ b/isabelle/Doc/Specification/Core.thy
@@ -143,11 +143,6 @@ text \<open>For the \<^emph>\<open>AddValue\<close> case, @{const evalValue} wil
 
 text \<open>@{thm evalValue_AddValue}\<close>
 
-text \<open>Addition is associative and commutative:\<close>
-
-text \<open>@{thm evalAddAssoc}\<close>
-
-text \<open>@{thm evalAddCommutative}\<close>
 
 subsubsection \<open>Subtraction\<close>
 
@@ -176,13 +171,8 @@ text \<open>Division is a special case because we only evaluate to natural numbe
 
 text \<open>@{thm [display,names_short, margin=40] evalValue_DivValue}\<close>
 
-(* \<open>TODO: lemmas around division? maybe extend the following to proof evalValue and not just div\<close>*)
-text \<open>@{thm divMultiply}\<close>
-text \<open>@{thm divAbsMultiply}\<close>
-(*text \<open>COMMENT(BWB): I suggest that the lemmas be (i) exact multiples divide with no remainder, (ii)
-      the remainder equals the excess above an exact multiple, and (iii) negation commutues with
-      division.\<close>
-*)
+text \<open>@{thm evalDivRoundToZero}\<close>
+
 subsubsection \<open>Choice Value\<close>
 
 text \<open>For the \<^emph>\<open>ChoiceValue\<close> case, @{const evalValue} will look in its state if a @{typ Party} has

--- a/marlowe-spec-test/src/Marlowe/Spec/Core/Arbitrary.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/Core/Arbitrary.hs
@@ -332,7 +332,7 @@ genState i = rawGen `suchThat` valid_state
       accounts <- vectorOf accountSize ((genParty i >*< genToken i) >*< liftGen arbitraryNonnegativeInteger)
       choices <- vectorOf choiceSize (genChoiceId i >*< liftGen arbitraryInteger)
       bounds <- vectorOf boundSize (liftGen genValueId >*< liftGen arbitraryInteger)
-      minTime <- liftGen arbitraryInteger
+      minTime <- liftGen arbitraryNonnegativeInteger
       pure $ State_ext accounts choices bounds minTime ()
     )
 genTransactionWarning :: InterpretJsonRequest -> GenT IO TransactionWarning


### PR DESCRIPTION
This PR adds a lemma that proves that if the numerator is lower than the denominator (in absolute), then `DivValue` rounds to `0`.