### PR TITLE
PLT-4250: `evalObservation` in spec-test

### DIFF
--- a/marlowe-spec-test/src/Marlowe/Spec/Interpret.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/Interpret.hs
@@ -32,6 +32,7 @@ data Request transport
   | ComputeTransaction (C.Transaction_ext ()) (C.State_ext ()) C.Contract
   | PlayTrace Integer C.Contract [C.Transaction_ext ()]
   | EvalValue (C.Environment_ext ()) (C.State_ext ()) C.Value
+  | EvalObservation (C.Environment_ext ()) (C.State_ext ()) C.Observation
 
 instance ToJSON (Request JSON.Value) where
   toJSON (TestRoundtripSerialization t v) = object
@@ -62,6 +63,12 @@ instance ToJSON (Request JSON.Value) where
     , "environment" .= toJSON env
     , "state" .= toJSON state
     , "value" .= toJSON val
+    ]
+  toJSON (EvalObservation env state obs) = object
+    [ "request" .= JSON.String "eval-observation"
+    , "environment" .= toJSON env
+    , "state" .= toJSON state
+    , "observation" .= toJSON obs
     ]
 
 data Response transport

--- a/marlowe-spec-test/src/Marlowe/Spec/LocalInterpret.hs
+++ b/marlowe-spec-test/src/Marlowe/Spec/LocalInterpret.hs
@@ -6,7 +6,7 @@ module Marlowe.Spec.LocalInterpret where
 import Arith (Int(..))
 import qualified Data.Aeson as JSON
 import Marlowe.Spec.Interpret (Response(..), Request(..))
-import Semantics (playTrace, computeTransaction, evalValue)
+import Semantics (playTrace, computeTransaction, evalValue, evalObservation)
 import Marlowe.Spec.TypeId (TypeId (..), fromTypeName)
 import Marlowe.Spec.Core.Serialization.Json
 import Data.Data (Proxy)
@@ -35,6 +35,11 @@ interpretLocal (EvalValue env state val) =
     $ RequestResponse
     $ JSON.toJSON
     $ evalValue env state val
+interpretLocal (EvalObservation env state obs) =
+  pure
+    $ RequestResponse
+    $ JSON.toJSON
+    $ evalObservation env state obs
 interpretLocal (ComputeTransaction t s c) =
   pure
     $ RequestResponse


### PR DESCRIPTION
The PR introduces `EvalObservation` to the test spec protocol.