### PR TITLE
Marlowe v3 RC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# XXX 2023 - Marlowe specification version 3, (RC2 or final?)
+# May 2023 - Marlowe specification version 3, RC2
 
 ## Specification
 - [PLT-4195](https://github.com/input-output-hk/marlowe/pull/161) - Change MoneyPreservation for AssetPreservation

--- a/isabelle/Doc/Specification/document/root.tex
+++ b/isabelle/Doc/Specification/document/root.tex
@@ -59,7 +59,7 @@ Simon Thompson \and \\
 Hernán Rajchert \and \\
 Brian Bush
 }
-\date{2 Dec 2022}
+\date{10 May 2023}
 \maketitle
 
 \tableofcontents


### PR DESCRIPTION
This PR just modifies the changelog and date of the PDF in order to make the second release candidate.

I've attached the candidate PDF: [specification-v3-rc2.pdf](https://github.com/input-output-hk/marlowe/files/11442580/specification-v3-rc2.pdf)
