### PR TITLE
Updated URLs to point to new Marlowe website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the specification of Marlowe, a domain-specific languag
 
 ## Learning about Marlowe and its ecosystem
 
-The [Marlowe tutorials](https://play.marlowe-finance.io/doc/marlowe/tutorials/index.html) introduce Marlowe and the Marlowe Playground.
+The [Marlowe tutorials](https://play.marlowe.iohk.io/doc/marlowe/tutorials/index.html) introduce Marlowe and the Marlowe Playground.
 
 The Cardano Docs has a [section on Marlowe](https://docs.cardano.org/marlowe/learn-about-marlowe) that explains what is marlowe and the different tools available.
 


### PR DESCRIPTION
Changed `marlowe-finance.io` to `marlowe.iohk.io`.